### PR TITLE
Automatically define schema based on types

### DIFF
--- a/ariadne/make_executable_schema.py
+++ b/ariadne/make_executable_schema.py
@@ -1,12 +1,51 @@
 from graphql import GraphQLSchema, parse
+from graphql.language.ast import (
+    Document,
+    ObjectTypeDefinition,
+    OperationTypeDefinition,
+    Name,
+    NamedType,
+    SchemaDefinition,
+)
 from graphql.utils.build_ast_schema import build_ast_schema
 
 from .add_resolve_functions_to_schema import add_resolve_functions_to_schema
 
 
+def build_default_schema(document: Document) -> SchemaDefinition:
+    defined_types = [
+        td.name.value
+        for td in document.definitions
+        if isinstance(td, ObjectTypeDefinition)
+    ]
+    operations = []
+    if "Query" in defined_types:
+        operations.append(
+            OperationTypeDefinition("query", type=NamedType(name=Name("Query")))
+        )
+    if "Mutation" in defined_types:
+        operations.append(
+            OperationTypeDefinition("mutation", type=NamedType(name=Name("Mutation")))
+        )
+    if "Subscription" in defined_types:
+        operations.append(
+            OperationTypeDefinition(
+                "subscription", type=NamedType(name=Name("Subscription"))
+            )
+        )
+    return SchemaDefinition(operation_types=operations, directives=[])
+
+
+def document_has_schema(document: Document) -> bool:
+    return any(isinstance(td, SchemaDefinition) for td in document.definitions)
+
+
 def build_schema(type_defs: str) -> GraphQLSchema:
-    ast_schema = parse(type_defs)
-    return build_ast_schema(ast_schema)
+    document = parse(type_defs)
+    if not document_has_schema(document):
+        schema_definition = build_default_schema(document)
+        document.definitions.append(schema_definition)
+    return build_ast_schema(document)
 
 
 def make_executable_schema(type_defs: str, resolvers: dict) -> GraphQLSchema:

--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -5,11 +5,6 @@ from ariadne import make_executable_schema
 
 def test_mutation_return_default_scalar():
     type_defs = """
-        schema {
-            query: Query
-            mutation: Mutation
-        }
-
         type Query {
             _: String
         }
@@ -30,11 +25,6 @@ def test_mutation_return_default_scalar():
 
 def test_mutation_return_type():
     type_defs = """
-        schema {
-            query: Query
-            mutation: Mutation
-        }
-
         type Query {
             _: String
         }

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -7,10 +7,6 @@ from ariadne import make_executable_schema
 
 def test_query_default_scalar():
     type_defs = """
-        schema {
-            query: Query
-        }
-
         type Query {
             test: String
         }
@@ -27,10 +23,6 @@ def test_query_default_scalar():
 
 def test_query_custom_scalar():
     type_defs = """
-        schema {
-            query: Query
-        }
-
         scalar Date
 
         type Query {
@@ -52,10 +44,6 @@ def test_query_custom_scalar():
 
 def test_query_custom_type_default_resolver():
     type_defs = """
-        schema {
-            query: Query
-        }
-
         type Query {
             test: Custom
         }
@@ -76,10 +64,6 @@ def test_query_custom_type_default_resolver():
 
 def test_query_custom_type_custom_resolver():
     type_defs = """
-        schema {
-            query: Query
-        }
-
         type Query {
             test: Custom
         }
@@ -103,10 +87,6 @@ def test_query_custom_type_custom_resolver():
 
 def test_query_custom_type_merged_custom_default_resolvers():
     type_defs = """
-        schema {
-            query: Query
-        }
-
         type Query {
             test: Custom
         }
@@ -131,10 +111,6 @@ def test_query_custom_type_merged_custom_default_resolvers():
 
 def test_query_with_argument():
     type_defs = """
-        schema {
-            query: Query
-        }
-
         type Query {
             test(returnValue: Int!): Int
         }


### PR DESCRIPTION
Automatically define the schema based on existing types if one is not already provided.

Allows us to use examples closer to these used by Apollo.

Unfortunately I don't have the time necessary to provide a better test suite.