### PR TITLE
Remove schema from readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ from ariadne import make_executable_schema
 from graphql import graphql
 
 type_defs = """
-    schema {
-        query: Query
-    }
-
     type Query {
         people: [Person!]!
     }


### PR DESCRIPTION
Update quickstart in readme to dont show `schema {}`, because we don't need it anymore.