### PR TITLE
Test input types in query and mutation

### DIFF
--- a/tests/test_mutations.py
+++ b/tests/test_mutations.py
@@ -49,3 +49,35 @@ def test_mutation_return_type():
     result = graphql(schema, 'mutation { addStaff(name: "Bob") { name } }')
     assert result.errors is None
     assert result.data == {"addStaff": {"name": "Bob"}}
+
+
+def test_mutation_input():
+    type_defs = """
+        type Query {
+            _: String
+        }
+
+        input StaffInput {
+            name: String
+        }
+
+        type Staff {
+            name: String
+        }
+
+        type Mutation {
+            addStaff(data: StaffInput): Staff
+        }
+    """
+
+    def resolve_add_staff(*_, data):
+        assert data == {"name": "Bob"}
+        return data
+
+    resolvers = {"Mutation": {"addStaff": resolve_add_staff}}
+
+    schema = make_executable_schema(type_defs, resolvers)
+
+    result = graphql(schema, 'mutation { addStaff(data: { name: "Bob" }) { name } }')
+    assert result.errors is None
+    assert result.data == {"addStaff": {"name": "Bob"}}

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -127,3 +127,27 @@ def test_query_with_argument():
     result = graphql(schema, "{ test(returnValue: 4) }")
     assert result.errors is None
     assert result.data == {"test": 42}
+
+
+def test_query_with_input():
+    type_defs = """
+        type Query {
+            test(data: TestInput): Int
+        }
+
+        input TestInput {
+            value: Int
+        }
+    """
+
+    def resolve_test(*_, data):
+        assert data == {"value": 4}
+        return "42"
+
+    resolvers = {"Query": {"test": resolve_test}}
+
+    schema = make_executable_schema(type_defs, resolvers)
+
+    result = graphql(schema, "{ test(data: { value: 4 }) }")
+    assert result.errors is None
+    assert result.data == {"test": 42}


### PR DESCRIPTION
This PR adds tests for query and mutation that use `input` types for data.

Fixes #17 