### PR TITLE
Add expose function

### DIFF
--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,6 +1,11 @@
 from .build_schema import build_schema_from_type_definitions
 from .executable_schema import make_executable_schema
-from .resolvers import add_resolve_functions_to_schema, default_resolver, resolve_to
+from .resolvers import (
+    add_resolve_functions_to_schema,
+    default_resolver,
+    expose,
+    resolve_to,
+)
 
 __all__ = [
     "add_resolve_functions_to_schema",
@@ -8,4 +13,5 @@ __all__ = [
     "default_resolver",
     "make_executable_schema",
     "resolve_to",
+    "expose",
 ]

--- a/ariadne/resolvers.py
+++ b/ariadne/resolvers.py
@@ -1,3 +1,4 @@
+import inflection
 from graphql import GraphQLObjectType, GraphQLScalarType, GraphQLSchema
 from graphql.execution.base import ResolveInfo
 
@@ -17,6 +18,15 @@ def resolve_to(name: str):
         return resolve_parent_field(parent, name)
 
     return resolver
+
+
+def expose(*fields):
+    """ Automatically resolve_to list of fields with camelcase names """
+
+    def camelize(name):
+        return inflection.camelize(name, uppercase_first_letter=False)
+
+    return {camelize(field): resolve_to(field) for field in fields}
 
 
 def add_resolve_functions_to_schema(schema: GraphQLSchema, resolvers: dict):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     version="0.0.2",
     url="https://github.com/mirumee/ariadne",
     packages=["ariadne"],
-    install_requires=["graphql-core>=2.1", "typing>=3.6.0"],
+    install_requires=["graphql-core>=2.1", "typing>=3.6.0", "inflection>=0.3.1"],
     classifiers=CLASSIFIERS,
     platforms=["any"],
 )


### PR DESCRIPTION
Since issue #21 is solved, we can define resolvers as follow:

```python
resolvers = {
    "User":  {"firstName": resolve_to("first_name")},
}
```

It seems to be common boilerplate for future uses, since we will repeat this line for every field, when we need to connect python and GraphQL naming conventions.

In this PR I developed experiment *expose* util function to help create it easier:

```python
resolvers = {
   "User": expose("first_name", "last_name"),
}
```

that will be equivalent to
```python
resolvers = {
    "User":  {
        "firstName": resolve_to("first_name"),
        "lastName": resolve_to("last_name"),
    },
}
```
