### PR TITLE
Release version 0.0.3 on pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     author_email="hello@mirumee.com",
     description="A functional implementation of a Python GraphQL server",
     license="BSD",
-    version="0.0.2",
+    version="0.0.3",
     url="https://github.com/mirumee/ariadne",
     packages=["ariadne"],
     install_requires=["graphql-core>=2.1", "typing>=3.6.0"],


### PR DESCRIPTION
Bump version to 0.0.3 and release GraphQL middleware to hyper-early adopters.