### PR TITLE
Rename resolve_to to resolve

### DIFF
--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,6 +1,6 @@
 from .build_schema import build_schema_from_type_definitions
 from .executable_schema import make_executable_schema
-from .resolvers import add_resolve_functions_to_schema, default_resolver, resolve_to
+from .resolvers import add_resolve_functions_to_schema, default_resolver, resolve
 from .wsgi_middleware import GraphQLMiddleware
 
 __all__ = [
@@ -9,5 +9,5 @@ __all__ = [
     "build_schema_from_type_definitions",
     "default_resolver",
     "make_executable_schema",
-    "resolve_to",
+    "resolve",
 ]

--- a/ariadne/resolvers.py
+++ b/ariadne/resolvers.py
@@ -16,7 +16,7 @@ def default_resolver(parent, info: ResolveInfo, **kwargs):
     return resolve_parent_field(parent, info.field_name, **kwargs)
 
 
-def resolve_to(name: str):
+def resolve(name: str):
     def resolver(parent, *_, **kwargs):
         return resolve_parent_field(parent, name, **kwargs)
 

--- a/tests/test_modularization.py
+++ b/tests/test_modularization.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 from graphql import graphql
 
-from ariadne import make_executable_schema, resolve_to
+from ariadne import make_executable_schema, resolve
 
 root_typedef = """
     type Query {
@@ -78,7 +78,7 @@ def test_accept_list_of_resolvers_maps():
     resolvers = [
         {
             "Query": {"user": lambda *_: Mock(first_name="Joe")},
-            "User": {"firstName": resolve_to("first_name")},
+            "User": {"firstName": resolve("first_name")},
         },
         {"Query": {"test": resolve_test}},
     ]

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 
 from graphql import graphql
 
-from ariadne import make_executable_schema, resolve_to
+from ariadne import make_executable_schema, resolve
 
 
 def test_query_root_type_default_resolver():
@@ -165,7 +165,7 @@ def test_mapping_resolver():
 
     resolvers = {
         "Query": {"user": lambda *_: {"first_name": "Joe"}},
-        "User": {"firstName": resolve_to("first_name")},
+        "User": {"firstName": resolve("first_name")},
     }
 
     schema = make_executable_schema(type_defs, resolvers)
@@ -188,7 +188,7 @@ def test_mapping_resolver_to_object_attribute():
 
     resolvers = {
         "Query": {"user": lambda *_: Mock(first_name="Joe")},
-        "User": {"firstName": resolve_to("first_name")},
+        "User": {"firstName": resolve("first_name")},
     }
 
     schema = make_executable_schema(type_defs, resolvers)
@@ -214,8 +214,8 @@ def test_default_resolver(mock_user, first_name, avatar, blog_posts):
     resolvers = {
         "Query": {"user": lambda *_: mock_user},
         "User": {
-            "firstName": resolve_to("first_name"),
-            "blogPosts": resolve_to("blog_posts"),
+            "firstName": resolve("first_name"),
+            "blogPosts": resolve("blog_posts"),
         },
     }
 


### PR DESCRIPTION
This PR renames `resolve_to` utility to just `resolve`, based on feedback we've got yesterday on internal demo we've did @mirumee.