### PR TITLE
Define object types for mutations

### DIFF
--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -33,7 +33,7 @@ In this example we have the following elements:
 
 ``Mutation`` type with two mutations: ``login`` mutation that requires username and password strings and returns bool with status, and ``logout`` that takes no arguments and just returns status.
 
-For the sake of simplicity, our mutations return bools, but really there is no such restriction. You can have a resolver that returns status code, an updated object, or an error message::
+For the sake of simplicity, our mutations return bools, but really there is no such restriction. In fact, it is recommended for mutations to return dedicated ``Payload`` types:
 
     type_def = """
         type Mutation {
@@ -47,6 +47,7 @@ For the sake of simplicity, our mutations return bools, but really there is no s
         }
     """
 
+Above mutation will return special type containing information about mutation's status, as well as either ``Error`` message or logged in ``User``.
 
 Writing resolvers
 -----------------
@@ -99,10 +100,10 @@ Imagine a mutation for creating ``Discussion`` that takes category, poster, titl
 
     type_def = """
         type Mutation {
-            createDiscussion(category: ID!, title: String!, isAnnouncement: Boolean, isClosed: Boolean): CreateDiscussionPayload
+            createDiscussion(category: ID!, title: String!, isAnnouncement: Boolean, isClosed: Boolean): DiscussionPayload
         }
 
-        type CreateDiscussionPayload {
+        type DiscussionPayload {
             status: Boolean!
             error: Error
             discussion: Discussion
@@ -115,13 +116,7 @@ GraphQL provides a better way for solving this problem: ``input`` allows us to m
 
     type_def = """
         type Mutation {
-            createDiscussion(input: DiscussionInput!): CreateDiscussionPayload
-        }
-
-        type CreateDiscussionPayload {
-            status: Boolean!
-            error: Error
-            discussion: Discussion
+            createDiscussion(input: DiscussionInput!): DiscussionPayload
         }
 
         input DiscussionInput {
@@ -157,20 +152,8 @@ Another advantage of ``input``-s is that they are reusable. If we later decide t
 
     type_def = """
         type Mutation {
-            createDiscussion(input: DiscussionInput!): CreateDiscussionPayload
-            updateDiscussion(discussion: ID!, input: DiscussionInput!): UpdateDiscussionPayload
-        }
-
-        type CreateDiscussionPayload {
-            status: Boolean!
-            error: Error
-            discussion: Discussion
-        }
-
-        type UpdateDiscussionPayload {
-            status: Boolean!
-            error: Error
-            discussion: Discussion
+            createDiscussion(input: DiscussionInput!): DiscussionPayload
+            updateDiscussion(discussion: ID!, input: DiscussionInput!): DiscussionPayload
         }
 
         input DiscussionInput {

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -37,11 +37,13 @@ For the sake of simplicity, our mutations return bools, but really there is no s
 
     type_def = """
         type Mutation {
-            login(username: String!, password: String!) {
-                status: String!
-                error: Error
-                user: User
-            }
+            login(username: String!, password: String!): LoginPayload
+        }
+
+        type LoginPayload {
+            status: Boolean!
+            error: Error
+            user: User
         }
     """
 
@@ -97,11 +99,13 @@ Imagine a mutation for creating ``Discussion`` that takes category, poster, titl
 
     type_def = """
         type Mutation {
-            createDiscussion(category: ID!, title: String!, isAnnouncement: Boolean, isClosed: Boolean) {
-                status: Boolean!
-                error: Error
-                discussion: Discussion
-            }
+            createDiscussion(category: ID!, title: String!, isAnnouncement: Boolean, isClosed: Boolean): CreateDiscussionPayload
+        }
+
+        type CreateDiscussionPayload {
+            status: Boolean!
+            error: Error
+            discussion: Discussion
         }
     """
 
@@ -111,11 +115,13 @@ GraphQL provides a better way for solving this problem: ``input`` allows us to m
 
     type_def = """
         type Mutation {
-            createDiscussion(input: DiscussionInput!) {
-                status: Boolean!
-                error: Error
-                discussion: Discussion
-            }
+            createDiscussion(input: DiscussionInput!): CreateDiscussionPayload
+        }
+
+        type CreateDiscussionPayload {
+            status: Boolean!
+            error: Error
+            discussion: Discussion
         }
 
         input DiscussionInput {
@@ -151,21 +157,25 @@ Another advantage of ``input``-s is that they are reusable. If we later decide t
 
     type_def = """
         type Mutation {
-            createDiscussion(input: DiscussionInput!) {
-                status: Boolean!
-                error: Error
-                discussion: Discussion
-            }
-            updateDiscussion(discussion: ID!, input: DiscussionInput!) {
-                status: Boolean!
-                error: Error
-                discussion: Discussion
-            }
+            createDiscussion(input: DiscussionInput!): CreateDiscussionPayload
+            updateDiscussion(discussion: ID!, input: DiscussionInput!): UpdateDiscussionPayload
+        }
+
+        type CreateDiscussionPayload {
+            status: Boolean!
+            error: Error
+            discussion: Discussion
+        }
+
+        type UpdateDiscussionPayload {
+            status: Boolean!
+            error: Error
+            discussion: Discussion
         }
 
         input DiscussionInput {
             category: ID!
-            title: String!,
+            title: String!
             isAnnouncement: Boolean
             isClosed: Boolean
         }

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -37,7 +37,7 @@ In this example we have the following elements:
 Mutation payloads
 -----------------
 
-For the sake of simplicity, our mutations return bools, but really there is no such requirement. In fact, it is generally considered a good practice for mutations to return dedicated ``payload`` types containing additional information about the result, such as errors or updated object::
+For the sake of simplicity, our mutations return bools, but really there is no such requirement. In fact, it is generally considered a good practice for mutations to return dedicated *payload* types containing additional information about the result, such as errors or updated object::
 
     type_def = """
         type Mutation {

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -64,8 +64,8 @@ Mutation resolvers are no different to resolvers used by other types. They are f
         user = auth.authenticate(username, password)
         if user:
             auth.login(request, user)
-            return True
-        return False
+            return {"status": True, "user": user}
+        return {"status": False, "error": "Invalid username or password"}
 
 
     def resolve_logout(_, info):

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -33,7 +33,11 @@ In this example we have the following elements:
 
 ``Mutation`` type with two mutations: ``login`` mutation that requires username and password strings and returns bool with status, and ``logout`` that takes no arguments and just returns status.
 
-For the sake of simplicity, our mutations return bools, but really there is no such restriction. In fact, it is recommended for mutations to return dedicated ``Payload`` types::
+
+Mutation payloads
+-----------------
+
+For the sake of simplicity, our mutations return bools, but really there is no such requirement. In fact, it is generally considered a good practice for mutations to return dedicated ``payload`` types containing additional information about the result, such as errors or updated object::
 
     type_def = """
         type Mutation {
@@ -48,6 +52,7 @@ For the sake of simplicity, our mutations return bools, but really there is no s
     """
 
 Above mutation will return special type containing information about mutation's status, as well as either ``Error`` message or logged in ``User``.
+
 
 Writing resolvers
 -----------------

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -100,7 +100,12 @@ Imagine a mutation for creating ``Discussion`` that takes category, poster, titl
 
     type_def = """
         type Mutation {
-            createDiscussion(category: ID!, title: String!, isAnnouncement: Boolean, isClosed: Boolean): DiscussionPayload
+            createDiscussion(
+                category: ID!,
+                title: String!,
+                isAnnouncement: Boolean,
+                isClosed: Boolean
+            ): DiscussionPayload
         }
 
         type DiscussionPayload {

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -33,7 +33,7 @@ In this example we have the following elements:
 
 ``Mutation`` type with two mutations: ``login`` mutation that requires username and password strings and returns bool with status, and ``logout`` that takes no arguments and just returns status.
 
-For the sake of simplicity, our mutations return bools, but really there is no such restriction. In fact, it is recommended for mutations to return dedicated ``Payload`` types:
+For the sake of simplicity, our mutations return bools, but really there is no such restriction. In fact, it is recommended for mutations to return dedicated ``Payload`` types::
 
     type_def = """
         type Mutation {


### PR DESCRIPTION
This PR defines custom object types for exemplary mutations. It's a good practice to define an object type for each migration separately, even if they initially contain the same fields.