### PR TITLE
Bump python requirement to 3.6, add 3.7 to tests matrix and drop 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+dist: xenial
 language: python
 python:
-  - 3.5
   - 3.6
+  - 3.7
 install:
   - python setup.py install
   - pip install pytest pytest-cov codecov pytest-mock snapshottest
@@ -11,7 +12,7 @@ after_success:
   - codecov
 matrix:
   include:
-    - python: 3.6
+    - python: 3.7
       script:
         - pip install black mypy pylint
         - pylint ariadne tests setup.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# CHANGELOG
+
+## 0.2.0 (UNRELEASED)
+
+- Removed support for Python 3.5 and added support for 3.7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You can use [GitHub issues](https://github.com/mirumee/ariadne/issues) to report
 
 ## Development setup
 
-Ariadne is written to support Python 3.5, 3.6 and 3.7.
+Ariadne is written to support Python 3.6 and 3.7.
 
 Codebase is formatted using [Black](https://github.com/ambv/black), and contents of `ariadne` package are annotated with types and validated using [mypy](http://mypy-lang.org/index.html).
 

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -18,7 +18,7 @@ def decompose_maps(resolvers_maps: List[dict]) -> Iterator[tuple]:
 
 
 def merge_resolvers(resolver_list: Iterator[tuple]) -> dict:
-    output = defaultdict(dict)  # type: dict
+    output: dict = defaultdict(dict)
     for key, resolver_name, resolver in resolver_list:
         output[key][resolver_name] = resolver
     return output

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ It presents a simple, easy-to-learn and extend API inspired by `Apollo Server <h
 Requirements and installation
 -----------------------------
 
-Ariadne requires Python 3.5 or 3.6 and can be installed from Pypi::
+Ariadne requires Python 3.6 or 3.7 and can be installed from Pypi::
 
     pip install ariadne
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ CLASSIFIERS = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.5",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
This PR also adds `CHANGELOG.md` file for tracking changes in new versions.

Fixes #31