### PR TITLE
Add gql() utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Removed support for Python 3.5 and added support for 3.7.
 - Moved to `GraphQL-core-next` that supports `async` resolvers, query execution and implements more recent version of GraphQL spec. If you are updating existing project, you will need to uninstall `graphql-core` before installing `graphql-core-next`, as both libraries use `graphql` namespace.
+- Added `gql()` utility that provides GraphQL string validation on declaration time, and enables use of [Apollo-GraphQL](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) plugin in Python code.
 - `Boolean` built-in scalar now checks the type of each serialized value. Returning values of type other than `bool`, `int` or `float` from a field resolver will result in a `Boolean cannot represent a non boolean value` error.
 - Redefining type in `type_defs` will now result in `TypeError` being raised. This is breaking change from previous behaviour where old type was simply replaced with new one.
 - Returning `None` from scalar `parse_literal` and `parse_value` function no longer results in GraphQL API producing default error message. Instead `None` will be passed further down to resolver or producing "value is required" error if its marked as such with `!` For old behaviour raise either `ValueError` or `TypeError`. See documentation for more details.

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@ Ariadne can be installed with pip:
 Following example creates API defining `Person` type and single query field `people` returning list of two persons. It also starts local dev server with [GraphQL Playground](https://github.com/prisma/graphql-playground) available on the `http://127.0.0.1:8888` address.
 
 ```python
-from ariadne import GraphQLMiddleware
+from ariadne import GraphQLMiddleware, gql
 
 # Define types using Schema Definition Language (https://graphql.org/learn/schema/)
-type_defs = """
+# Wrapping string in gql function provides validation and better error traceback
+type_defs = gql("""
     type Query {
         people: [Person!]!
     }
@@ -41,7 +42,7 @@ type_defs = """
         age: Int
         fullName: String
     }
-"""
+""")
 
 
 # Resolvers are simple python functions

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,5 +1,6 @@
 from .executable_schema import make_executable_schema
 from .resolvers import add_resolve_functions_to_schema, default_resolver, resolve_to
+from .utils import gql
 from .wsgi_middleware import GraphQLMiddleware
 
 __all__ = [
@@ -8,4 +9,5 @@ __all__ = [
     "default_resolver",
     "make_executable_schema",
     "resolve_to",
+    "gql",
 ]

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -1,0 +1,6 @@
+from graphql import parse
+
+
+def gql(value: str) -> str:
+    parse(value)
+    return value

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -30,6 +30,32 @@ Using the SDL, our ``Query`` type definition will look like this::
 The ``type Query { }`` block declares the type, ``hello`` is the field definition, ``String`` is the return value type, and the exclamation mark following it means that returned value will never be ``null``.
 
 
+Validating schema
+-----------------
+
+Ariadne provides tiny ``gql`` utility function that takes single argument: GraphQL string, validates it and raises descriptive ``GraphQLSyntaxError``, or returns original unmodified string if its correct::
+
+    from ariadne import gql
+
+    type_defs = gql("""
+        type Query {
+            hello String!
+        }
+    """)
+
+If we try to run above code now, we will get an error pointing to our incorrect syntax within our ``type_defs`` declaration::
+
+    graphql.error.syntax_error.GraphQLSyntaxError: Syntax Error: Expected :, found Name
+
+    GraphQL request (3:19)
+        type Query {
+            hello String!
+                  ^
+        }
+
+Using ``gql`` is optional, but without it above error would occur during your server's initialization and point to somewhere inside Ariadne's GraphQL initialization logic, making tracking down incorrect place trickier if your API is large and spread across many modules.
+
+
 Resolvers
 ---------
 
@@ -105,13 +131,13 @@ Completed code
 
 For reference here is complete code of the API from this guide::
 
-    from ariadne import GraphQLMiddleware
+    from ariadne import GraphQLMiddleware, gql
 
-    type_defs = """
+    type_defs = gql("""
         type Query {
             hello: String!
         }
-    """
+    """)
 
 
     def resolve_hello(_, info):

--- a/tests/test_gql_util.py
+++ b/tests/test_gql_util.py
@@ -45,7 +45,7 @@ def test_invalid_graphql_query_string_causes_syntax_error():
             """
                 query TestQuery {
                     auth
-                    users 
+                    users
                         id
                         username
                     }

--- a/tests/test_gql_util.py
+++ b/tests/test_gql_util.py
@@ -4,7 +4,7 @@ from graphql.error import GraphQLSyntaxError
 from ariadne import gql
 
 
-def test_valid_graphqll_string_is_passed_as_is():
+def test_valid_graphql_schema_string_is_returned_unchanged():
     sdl = """
         type User {
             username: String!
@@ -14,12 +14,41 @@ def test_valid_graphqll_string_is_passed_as_is():
     assert sdl == result
 
 
-def test_invalid_graphql_string_raises_syntax_error():
+def test_invalid_graphql_schema_string_causes_syntax_error():
     with pytest.raises(GraphQLSyntaxError):
         gql(
             """
                 type User {
                     username String!
+                }
+            """
+        )
+
+
+def test_valid_graphql_query_string_is_returned_unchanged():
+    query = """
+        query TestQuery {
+            auth
+            users {
+                id
+                username
+            }
+        }
+    """
+    result = gql(query)
+    assert query == result
+
+
+def test_invalid_graphql_query_string_causes_syntax_error():
+    with pytest.raises(GraphQLSyntaxError):
+        gql(
+            """
+                query TestQuery {
+                    auth
+                    users 
+                        id
+                        username
+                    }
                 }
             """
         )

--- a/tests/test_gql_util.py
+++ b/tests/test_gql_util.py
@@ -1,0 +1,25 @@
+import pytest
+from graphql.error import GraphQLSyntaxError
+
+from ariadne import gql
+
+
+def test_valid_graphqll_string_is_passed_as_is():
+    sdl = """
+        type User {
+            username: String!
+        }
+    """
+    result = gql(sdl)
+    assert sdl == result
+
+
+def test_invalid_graphql_string_raises_syntax_error():
+    with pytest.raises(GraphQLSyntaxError):
+        gql(
+            """
+                type User {
+                    username String!
+                }
+            """
+        )


### PR DESCRIPTION
This PR adds `gql()` utility function for declaration-time validation of GraphQL strings and coloring/in IDE validation using Apollo-GraphQL in Python code.

Fixes #47