### PR TITLE
Re-word changelog and make test fixtures little more real-worldly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Removed support for Python 3.5 and added support for 3.7.
 - Moved to `GraphQL-core-next` that supports `async` resolvers, query execution and implements more recent version of GraphQL spec. If you are updating existing project, you will need to uninstall `graphql-core` before installing `graphql-core-next`, as both libraries use `graphql` namespace.
 - Added `gql()` utility that provides GraphQL string validation on declaration time, and enables use of [Apollo-GraphQL](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) plugin in Python code.
-- Added `start_simple_server()` shortcut for creating simple server with `GraphQLMiddleware.make_server()` and then running it with `serve_forever()`.
+- Added `start_simple_server()` shortcut that abstracts away dev server creation and start using `GraphQLMiddleware.make_server()`.
 - `Boolean` built-in scalar now checks the type of each serialized value. Returning values of type other than `bool`, `int` or `float` from a field resolver will result in a `Boolean cannot represent a non boolean value` error.
 - Redefining type in `type_defs` will now result in `TypeError` being raised. This is breaking change from previous behaviour where old type was simply replaced with new one.
 - Returning `None` from scalar `parse_literal` and `parse_value` function no longer results in GraphQL API producing default error message. Instead `None` will be passed further down to resolver or producing "value is required" error if its marked as such with `!` For old behaviour raise either `ValueError` or `TypeError`. See documentation for more details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Removed support for Python 3.5 and added support for 3.7.
 - Moved to `GraphQL-core-next` that supports `async` resolvers, query execution and implements more recent version of GraphQL spec. If you are updating existing project, you will need to uninstall `graphql-core` before installing `graphql-core-next`, as both libraries use `graphql` namespace.
 - Added `gql()` utility that provides GraphQL string validation on declaration time, and enables use of [Apollo-GraphQL](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) plugin in Python code.
-- Added `start_simple_server()` shortcut that abstracts away dev server creation and start using `GraphQLMiddleware.make_server()`.
+- Added `start_simple_server()` shortcut function for a quick dev server creation, abstracting away the `GraphQLMiddleware.make_server()` from first time users.
 - `Boolean` built-in scalar now checks the type of each serialized value. Returning values of type other than `bool`, `int` or `float` from a field resolver will result in a `Boolean cannot represent a non boolean value` error.
 - Redefining type in `type_defs` will now result in `TypeError` being raised. This is breaking change from previous behaviour where old type was simply replaced with new one.
 - Returning `None` from scalar `parse_literal` and `parse_value` function no longer results in GraphQL API producing default error message. Instead `None` will be passed further down to resolver or producing "value is required" error if its marked as such with `!` For old behaviour raise either `ValueError` or `TypeError`. See documentation for more details.

--- a/tests/test_start_simple_server.py
+++ b/tests/test_start_simple_server.py
@@ -26,7 +26,7 @@ def type_defs():
 
 @pytest.fixture
 def resolvers():
-    return {}
+    return {"Query": {"hello": lambda *_: "Hello"}}
 
 
 def test_wsgi_simple_server_serve_forever_is_called(
@@ -45,20 +45,20 @@ def test_keyboard_interrupt_is_handled_gracefully(mocker, type_defs, resolvers):
 
 
 def test_type_defs_resolvers_host_and_ip_are_passed_to_graphql_middleware(
-    middleware_make_simple_server_mock
+    middleware_make_simple_server_mock, type_defs, resolvers
 ):
-    start_simple_server("type_defs", "resolvers", "0.0.0.0", 4444)
+    start_simple_server(type_defs, resolvers, "0.0.0.0", 4444)
     middleware_make_simple_server_mock.assert_called_once_with(
-        "type_defs", "resolvers", "0.0.0.0", 4444
+        type_defs, resolvers, "0.0.0.0", 4444
     )
 
 
 def test_default_host_and_ip_are_passed_to_graphql_middleware_if_not_set(
-    middleware_make_simple_server_mock
+    middleware_make_simple_server_mock, type_defs, resolvers
 ):
-    start_simple_server("type_defs", "resolvers")
+    start_simple_server(type_defs, resolvers)
     middleware_make_simple_server_mock.assert_called_once_with(
-        "type_defs", "resolvers", "127.0.0.1", 8888
+        type_defs, resolvers, "127.0.0.1", 8888
     )
 
 


### PR DESCRIPTION
I wasn't entirely happy with all changes introduced in  #68, so I am following up with new PR:

- Reworded changelog a little.
- Move some `start_simple_server` tests to fixtures that better represent real-world use.