### PR TITLE
Move library API to objects

### DIFF
--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,14 +1,18 @@
 from .executable_schema import make_executable_schema
 from .resolvers import add_resolve_functions_to_schema, default_resolver, resolve_to
-from .utils import gql, start_simple_server
+from .schema import Schema
+from .simple_server import start_simple_server
+from .utils import convert_camel_case_to_snake, gql
 from .wsgi_middleware import GraphQLMiddleware
 
 __all__ = [
     "GraphQLMiddleware",
+    "Schema",
     "add_resolve_functions_to_schema",
+    "convert_camel_case_to_snake",
     "default_resolver",
+    "gql",
     "make_executable_schema",
     "resolve_to",
-    "gql",
     "start_simple_server",
 ]

--- a/ariadne/schema.py
+++ b/ariadne/schema.py
@@ -1,0 +1,33 @@
+from typing import List, Union
+
+from graphql import GraphQLObjectType, GraphQLScalarType, GraphQLSchema, build_schema
+
+from .schema_types import ObjectType, ScalarType
+
+
+class Schema:
+    _schema: GraphQLSchema
+
+    def __init__(self, type_defs: Union[str, List[str]]):
+        if isinstance(type_defs, list):
+            type_defs = join_type_defs(type_defs)
+        self._schema = build_schema(type_defs)
+
+    def type(self, type_name: str) -> Union[ObjectType, ScalarType]:
+        graphql_type = self._schema.type_map.get(type_name)
+        if not graphql_type:
+            valid_types = filter(
+                lambda t: not t.startswith("__"), self._schema.type_map.keys()
+            )
+            raise ValueError(
+                "%s type is not defined in this schema. Defined types: %s"
+                % (type_name, ", ".join(valid_types))
+            )
+
+        if isinstance(graphql_type, GraphQLObjectType):
+            return ObjectType(graphql_type)
+        if isinstance(graphql_type, GraphQLScalarType):
+            return ScalarType(graphql_type)
+
+    def make_executable(self) -> GraphQLSchema:
+        return self._schema

--- a/ariadne/schema_types.py
+++ b/ariadne/schema_types.py
@@ -1,0 +1,57 @@
+from graphql import GraphQLField, GraphQLObjectType, GraphQLScalarType
+from typing import Any, Callable
+
+from .resolvers import resolve_to
+
+
+class ScalarType:
+    def __init__(self, scalar: GraphQLScalarType):
+        self.scalar = scalar
+
+    def serialize(self):
+        def register_serialize(serialize: Callable) -> Any:
+            self.scalar.serialize = serialize
+            return serialize
+
+        return register_serialize
+
+    def parse_value(self):
+        def register_parse_value(parse_value: Callable) -> Any:
+            self.scalar.parse_value = parse_value
+            return parse_value
+
+        return register_parse_value
+
+    def parse_literal(self):
+        def register_parse_value(parse_literal: Callable) -> Any:
+            self.scalar.parse_literal = parse_literal
+            return parse_literal
+
+        return register_parse_literal
+
+
+class ObjectType:
+    def __init__(self, object: GraphQLObjectType):
+        self.object = object
+
+    def field(self, field_name: str) -> GraphQLField:
+        field = self.object.fields.get(field_name)
+        if not field:
+            valid_fields = self.object.fields.keys()
+            raise ValueError(
+                "%s field is not defined in this object. Defined fields: %s"
+                % (field_name, ", ".join(valid_fields))
+            )
+        return field
+
+    def alias(self, field_name: str, to: str):
+        field = self.field(field_name)
+        field.resolve = resolve_to(to)
+
+    def resolve(self, field_name: str):
+        def register_resolver(resolver: Callable) -> Any:
+            field = self.field(field_name)
+            field.resolve = resolver
+            return resolver
+
+        return register_resolver

--- a/ariadne/simple_server.py
+++ b/ariadne/simple_server.py
@@ -1,0 +1,11 @@
+from .schema import Schema
+from .wsgi_middleware import GraphQLMiddleware
+
+
+def start_simple_server(schema: Schema, host: str = "127.0.0.1", port: int = 8888):
+    try:
+        print("Simple GraphQL server is running on the http://%s:%s" % (host, port))
+        graphql_server = GraphQLMiddleware.make_simple_server(schema, host, port)
+        graphql_server.serve_forever()
+    except KeyboardInterrupt:
+        pass

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -1,8 +1,17 @@
-from typing import List, Union
+from typing import List
 
 from graphql import parse
 
-from .wsgi_middleware import GraphQLMiddleware
+from .schema import Schema
+
+
+def convert_camel_case_to_snake(graphql_name: str) -> str:
+    python_name = ""
+    for i, c in enumerate(graphql_name.lower()):
+        if i and c != graphql_name[i]:
+            python_name += "_"
+        python_name += c
+    return python_name
 
 
 def gql(value: str) -> str:
@@ -10,17 +19,5 @@ def gql(value: str) -> str:
     return value
 
 
-def start_simple_server(
-    type_defs: Union[str, List[str]],
-    resolvers: Union[dict, List[dict]],
-    host: str = "127.0.0.1",
-    port: int = 8888,
-):
-    try:
-        print("Simple GraphQL server is running on the http://%s:%s" % (host, port))
-        graphql_server = GraphQLMiddleware.make_simple_server(
-            type_defs, resolvers, host, port
-        )
-        graphql_server.serve_forever()
-    except KeyboardInterrupt:
-        pass
+def join_type_defs(type_defs: List[str]) -> str:
+    return "\n\n".join(t.strip() for t in type_defs)

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -2,8 +2,6 @@ from typing import List
 
 from graphql import parse
 
-from .schema import Schema
-
 
 def convert_camel_case_to_snake(graphql_name: str) -> str:
     python_name = ""

--- a/tests/test_case_conversion_util.py
+++ b/tests/test_case_conversion_util.py
@@ -1,0 +1,36 @@
+from ariadne import convert_camel_case_to_snake
+
+
+def test_snake_case_name_is_not_changed():
+    test_str = "test"
+    assert convert_camel_case_to_snake(test_str) == test_str
+
+
+def test_two_words_snake_case_name_is_not_changed():
+    test_str = "test_name"
+    assert convert_camel_case_to_snake(test_str) == test_str
+
+
+def test_three_words_snake_case_name_is_not_changed():
+    test_str = "test_complex_name"
+    assert convert_camel_case_to_snake(test_str) == test_str
+
+
+def test_camel_case_name_is_lowercased():
+    assert convert_camel_case_to_snake("Test") == "test"
+
+
+def test_two_words_camel_case_name_is_converted():
+    assert convert_camel_case_to_snake("TestName") == "test_name"
+
+
+def test_two_words_pascal_case_name_is_converted():
+    assert convert_camel_case_to_snake("testName") == "test_name"
+
+
+def test_three_words_camel_case_name_is_converted():
+    assert convert_camel_case_to_snake("TestComplexName") == "test_complex_name"
+
+
+def test_three_words_pascal_case_name_is_converted():
+    assert convert_camel_case_to_snake("testComplexName") == "test_complex_name"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,45 @@
+import pytest
+from graphql import GraphQLSchema
+
+from ariadne import Schema
+from ariadne.schema_types import ObjectType, ScalarType
+
+type_defs = """
+    type Query {
+        hello: String
+    }
+
+    scalar Datetime
+"""
+
+
+def test_class_takes_sdl_string_and_builds_schema():
+    schema = Schema(type_defs)
+    assert isinstance(schema._schema, GraphQLSchema)
+
+
+def test_class_takes_list_of_sdl_strings_and_builds_schema():
+    extra_typedef = """
+        type Log {
+            text: String!
+        }
+    """
+
+    schema = Schema([type_defs, extra_typedef])
+    assert isinstance(schema._schema, GraphQLSchema)
+
+
+def test_type_getter_returns_type_proxy_for_existing_type():
+    schema = Schema(type_defs)
+    assert isinstance(schema.type("Query"), ObjectType)
+
+
+def test_type_getter_returns_scalar_proxy_for_existing_scalar():
+    schema = Schema(type_defs)
+    assert isinstance(schema.type("Datetime"), ScalarType)
+
+
+def test_type_getter_raises_value_error_for_undefined_type():
+    schema = Schema(type_defs)
+    with pytest.raises(ValueError):
+        schema.type("Undefined")


### PR DESCRIPTION
This PR replaces current procedural API inspired by Apollo-server with more *pythonic* object API.

This reverses order in which resolvers are defined and mapped to type, saving us gotchas from forgetting about updating resolvers map:

```python
schema = Schema(type_defs)

query = schema.type("Query")

@query.resolve("persons")
def resolve_persons(*_):
    return []
```

As usual, this is a work in progress, and there will be dragons ;)


### TODO

- [ ] Finalize API
- [ ] Write tests
- [ ] Update docs
- [ ] Update readme
- [ ] Nuke old unused code
- [ ] Update changelog