### PR TITLE
Add readthedocs.yml config to force py3.6 for docs builds

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+    image: latest
+
+python:
+    version: 3.6


### PR DESCRIPTION
This PR adds `readthedocs.yml` file that tells RTD to use py3.6 for docs builds.