### PR TITLE
Fix type definition for Resolver

### DIFF
--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -1,7 +1,7 @@
 from typing import Any, Callable
 from typing_extensions import Protocol
 
-from graphql.type import GraphQLResolveInfo, GraphQLSchema
+from graphql.type import GraphQLSchema
 
 
 class Bindable(Protocol):
@@ -9,6 +9,9 @@ class Bindable(Protocol):
         pass  # pragma: no cover
 
 
-Resolver = Callable[[Any, GraphQLResolveInfo], Any]
+# Note: this should be [Any, GraphQLResolveInfo, **kwargs],
+# but this is not achieveable with python types yet:
+# https://github.com/python/typing/issues/264
+Resolver = Callable[..., Any]
 
 ScalarOperation = Callable[[Any], Any]

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -11,7 +11,7 @@ class Bindable(Protocol):
 
 # Note: this should be [Any, GraphQLResolveInfo, **kwargs],
 # but this is not achieveable with python types yet:
-# https://github.com/python/typing/issues/264
+# https://github.com/mirumee/ariadne/pull/79
 Resolver = Callable[..., Any]
 
 ScalarOperation = Callable[[Any], Any]


### PR DESCRIPTION
Our current type annotation for `Resolver` doesn't support resolvers accepting arguments, thus introducing noise to `Mypy` that resolver function doesn't meet the signature of `[Any, GraphQLResolveInfo]`.

This problem is [known to MyPy authors](https://github.com/python/typing/issues/264), but in the meantime we should update our `Resolver` type to be more forgiving so dev tools and code linters don't confuse devs using Ariadne.

This PR changes annotation to `Callable[..., Any]`.