### PR TITLE
Bump python package version number to 0.2.0b1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     license="BSD",
-    version="0.1.0",
+    version="0.2.0b1",
     url="https://github.com/mirumee/ariadne",
     packages=["ariadne"],
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import os
 from setuptools import setup
 
 CLASSIFIERS = [
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",


### PR DESCRIPTION
This PR bumps version number for Ariadne to 0.2.0b1, so we can make beta release on PYPI before proper 0.2.0 release after new year.