### PR TITLE
Bump version to 0.2.0 and add release date to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.2.0 (UNRELEASED)
+## 0.2.0 (07.01.2019)
 
 - Removed support for Python 3.5 and added support for 3.7.
 - Moved to `GraphQL-core-next` that supports `async` resolvers, query execution and implements a more recent version of GraphQL spec. If you are updating an existing project, you will need to uninstall `graphql-core` before installing `graphql-core-next`, as both libraries use `graphql` namespace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.2.0 (07.01.2019)
+## 0.2.0 (2019-01-07)
 
 - Removed support for Python 3.5 and added support for 3.7.
 - Moved to `GraphQL-core-next` that supports `async` resolvers, query execution and implements a more recent version of GraphQL spec. If you are updating an existing project, you will need to uninstall `graphql-core` before installing `graphql-core-next`, as both libraries use `graphql` namespace.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     long_description=README,
     long_description_content_type="text/markdown",
     license="BSD",
-    version="0.2.0b1",
+    version="0.2.0",
     url="https://github.com/mirumee/ariadne",
     packages=["ariadne"],
     install_requires=[


### PR DESCRIPTION
This PR bumps version to 0.2.0 and adds release date for 0.2.0 entry in our changelog.

Note: merging this PR doesn't equal pypi push, we still have a moment to do last-second changes if we  need.