### PR TITLE
Support transforming enum values to internal representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.3.0 (UNRELEASED)
+
+- Added `Enum` type for mapping enum variables to internal representation used in application.
+
 ## 0.2.0 (2019-01-07)
 
 - Removed support for Python 3.5 and added support for 3.7.

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,3 +1,4 @@
+from .enums import Enum
 from .executable_schema import make_executable_schema
 from .load_schema import load_schema_from_path
 from .resolvers import (
@@ -16,6 +17,7 @@ from .wsgi_middleware import GraphQLMiddleware
 
 
 __all__ = [
+    "Enum",
     "FallbackResolversSetter",
     "GraphQLMiddleware",
     "ResolverMap",

--- a/ariadne/enums.py
+++ b/ariadne/enums.py
@@ -7,11 +7,10 @@ from graphql.type import GraphQLEnumType, GraphQLSchema
 from .types import Bindable
 
 
-GraphQLEnumValues = Union[Dict[str, Any], enum.Enum, enum.IntEnum]
-
-
 class Enum(Bindable):
-    def __init__(self, name: str, values=GraphQLEnumValues) -> None:
+    def __init__(
+        self, name: str, values=Union[Dict[str, Any], enum.Enum, enum.IntEnum]
+    ) -> None:
         self.name = name
         try:
             self.values = values.__members__  # pylint: disable=no-member

--- a/ariadne/enums.py
+++ b/ariadne/enums.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Any, Dict
 
 from graphql.type import GraphQLEnumType, GraphQLSchema
 
@@ -6,7 +6,7 @@ from .types import Bindable
 
 
 class Enum(Bindable):
-    def __init__(self, name: str, values=Dict[str, any]) -> None:
+    def __init__(self, name: str, values=Dict[str, Any]) -> None:
         self.name = name
         self.values = values
 

--- a/ariadne/enums.py
+++ b/ariadne/enums.py
@@ -1,0 +1,31 @@
+from typing import Dict
+
+from graphql.type import GraphQLEnumType, GraphQLSchema
+
+from .types import Bindable
+
+
+class Enum(Bindable):
+    def __init__(self, name: str, values=Dict[str, any]) -> None:
+        self.name = name
+        self.values = values
+
+    def bind_to_schema(self, schema: GraphQLSchema) -> None:
+        graphql_type = schema.type_map.get(self.name)
+        self.validate_graphql_type(graphql_type)
+
+        for key, value in self.values.items():
+            if key not in graphql_type.values:
+                raise ValueError(
+                    "Value %s is not defined on enum %s" % (key, self.name)
+                )
+            graphql_type.values[key].value = value
+
+    def validate_graphql_type(self, graphql_type: str) -> None:
+        if not graphql_type:
+            raise ValueError("Enum %s is not defined in the schema" % self.name)
+        if not isinstance(graphql_type, GraphQLEnumType):
+            raise ValueError(
+                "%s is defined in the schema, but it is instance of %s (expected %s)"
+                % (self.name, type(graphql_type).__name__, GraphQLEnumType.__name__)
+            )

--- a/ariadne/enums.py
+++ b/ariadne/enums.py
@@ -1,14 +1,22 @@
-from typing import Any, Dict
+import enum
+
+from typing import Any, Dict, Union
 
 from graphql.type import GraphQLEnumType, GraphQLSchema
 
 from .types import Bindable
 
 
+GraphQLEnumValues = Union[Dict[str, Any], enum.Enum, enum.IntEnum]
+
+
 class Enum(Bindable):
-    def __init__(self, name: str, values=Dict[str, Any]) -> None:
+    def __init__(self, name: str, values=GraphQLEnumValues) -> None:
         self.name = name
-        self.values = values
+        try:
+            self.values = values.__members__  # pylint: disable=no-member
+        except AttributeError:
+            self.values = values
 
     def bind_to_schema(self, schema: GraphQLSchema) -> None:
         graphql_type = schema.type_map.get(self.name)

--- a/docs/enums.rst
+++ b/docs/enums.rst
@@ -93,3 +93,25 @@ Ariadne provides ``Enum`` utility class thats allows you to delegate this task t
     )
 
 Include the ``post_weight`` instance in list of ``resolvers`` passed to your GraphQL server, and it will automatically translate Enums between their GraphQL and Python values.
+
+Instead of ``dict`` you may use either ``enum.Enum`` or ``enum.IntEnum``::
+
+    import enum
+
+    from ariadne import Enum
+
+    class PostWeight(enum.Enum):
+        STANDARD = "standard"
+        PINNED = "pin"
+        PROMOTED = "promo"
+
+    post_weight = Enum("PostWeight", PostWeight)
+
+    # or using IntEnum
+
+    class PostWeight(enum.IntEnum):
+        STANDARD = 1
+        PINNED = 2
+        PROMOTED = 3
+
+    post_weight = Enum("PostWeight", PostWeight)

--- a/docs/enums.rst
+++ b/docs/enums.rst
@@ -81,6 +81,21 @@ In database, the application may store those weights as integers from 0 to 2. No
 
 Ariadne provides ``Enum`` utility class thats allows you to delegate this task to GraphQL server::
 
+    import enum
+
+    from ariadne import Enum
+
+    class PostWeight(enum.IntEnum):
+        STANDARD = 1
+        PINNED = 2
+        PROMOTED = 3
+
+    post_weight = Enum("PostWeight", PostWeight)
+
+Include the ``post_weight`` instance in list of ``resolvers`` passed to your GraphQL server, and it will automatically translate Enums between their GraphQL and Python values.
+
+Instead of ``Enum`` you may use ``dict``::
+
     from ariadne import Enum
 
     post_weight = Enum(
@@ -92,26 +107,4 @@ Ariadne provides ``Enum`` utility class thats allows you to delegate this task t
         },
     )
 
-Include the ``post_weight`` instance in list of ``resolvers`` passed to your GraphQL server, and it will automatically translate Enums between their GraphQL and Python values.
-
-Instead of ``dict`` you may use either ``enum.Enum`` or ``enum.IntEnum``::
-
-    import enum
-
-    from ariadne import Enum
-
-    class PostWeight(enum.Enum):
-        STANDARD = "standard"
-        PINNED = "pin"
-        PROMOTED = "promo"
-
-    post_weight = Enum("PostWeight", PostWeight)
-
-    # or using IntEnum
-
-    class PostWeight(enum.IntEnum):
-        STANDARD = 1
-        PINNED = 2
-        PROMOTED = 3
-
-    post_weight = Enum("PostWeight", PostWeight)
+Both ``Enum`` and ``IntEnum`` are supported by ``ariadne.Enum``.

--- a/docs/enums.rst
+++ b/docs/enums.rst
@@ -58,4 +58,38 @@ GraphQL failed to find ``TEST`` in ``UserStatus``, and returned error without ca
             ]
         }
     }
-  
+
+
+Mapping to internal values
+--------------------------
+
+By default enum values are represented as Python strings, but Ariadne also supports mapping GraphQL enums to custom values.
+
+Imagine posts on social site that can have weights like "standard", "pinned" and "promoted"::
+
+    type Post {
+        weight: PostWeight
+    }
+
+    enum PostWeight {
+        STANDARD
+        PINNED
+        PROMOTED
+    }
+
+In database, the application may store those weights as integers from 0 to 2. Normally, you would have to implement custom resolver transforming GraphQL representation to the integer but, like with scalars, you would have to remember to use this boiler plate on every use.
+
+Ariadne provides ``Enum`` utility class thats allows you to delegate this task to GraphQL server::
+
+    from ariadne import Enum
+
+    post_weight = Enum(
+        "PostWeight",
+        {
+            "STANDARD": 1,
+            "PINNED": 2,
+            "PROMOTED": 3,
+        },
+    )
+
+Include the ``post_weight`` instance in list of ``resolvers`` passed to your GraphQL server, and it will automatically translate Enums between their GraphQL and Python values.

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -87,7 +87,7 @@ def test_attempt_bind_custom_enum_to_schema_enum_missing_value_raises_error(
 ):
     enum = Enum("Episode", {"JARJAR": 1999})
     with pytest.raises(ValueError):
-        enum.bind_to_schema(schema_with_enum)
+        enum.bind_to_schema(schema_with_enum)  # pylint: disable=no-member
 
 
 custom_enum = Enum("Episode", {"NEWHOPE": 1977, "EMPIRE": 1980, "JEDI": 1983})

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,3 +1,5 @@
+import enum
+
 import pytest
 
 from graphql import graphql_sync, build_schema
@@ -71,43 +73,97 @@ def schema_with_enum():
 
 
 def test_attempt_bind_custom_enum_to_undefined_type_raises_error(schema_with_enum):
-    enum = Enum("Undefined", {})
+    graphql_enum = Enum("Undefined", {})
     with pytest.raises(ValueError):
-        enum.bind_to_schema(schema_with_enum)
+        graphql_enum.bind_to_schema(schema_with_enum)
 
 
 def test_attempt_bind_custom_enum_to_wrong_schema_type_raises_error(schema_with_enum):
-    enum = Enum("Query", {})
+    graphql_enum = Enum("Query", {})
     with pytest.raises(ValueError):
-        enum.bind_to_schema(schema_with_enum)
+        graphql_enum.bind_to_schema(schema_with_enum)
 
 
 def test_attempt_bind_custom_enum_to_schema_enum_missing_value_raises_error(
     schema_with_enum
 ):
-    enum = Enum("Episode", {"JARJAR": 1999})
+    graphql_enum = Enum("Episode", {"JARJAR": 1999})
     with pytest.raises(ValueError):
-        enum.bind_to_schema(schema_with_enum)  # pylint: disable=no-member
+        graphql_enum.bind_to_schema(schema_with_enum)  # pylint: disable=no-member
 
 
-custom_enum = Enum("Episode", {"NEWHOPE": 1977, "EMPIRE": 1980, "JEDI": 1983})
+dict_enum = Enum("Episode", {"NEWHOPE": 1977, "EMPIRE": 1980, "JEDI": 1983})
 
 TEST_INTERNAL_VALUE = 1977
 
 
-def test_enum_is_resolved_from_internal_value():
+def test_dict_enum_is_resolved_from_internal_value():
     query = ResolverMap("Query")
     query.field("testEnum")(lambda *_: TEST_INTERNAL_VALUE)
 
-    schema = make_executable_schema([enum_definition, enum_field], [query, custom_enum])
+    schema = make_executable_schema([enum_definition, enum_field], [query, dict_enum])
+    result = graphql_sync(schema, "{ testEnum }")
+    assert result.data["testEnum"] == TEST_VALUE
+
+
+def test_dict_enum_arg_is_transformed_to_internal_value():
+    query = ResolverMap("Query")
+    query.field("testEnum")(lambda *_, value: value == TEST_INTERNAL_VALUE)
+
+    schema = make_executable_schema([enum_definition, enum_param], [query, dict_enum])
+    result = graphql_sync(schema, "{ testEnum(value: %s) }" % TEST_VALUE)
+    assert result.data["testEnum"] is True
+
+
+class PyEnum(enum.Enum):
+    NEWHOPE = 1977
+    EMPIRE = 1980
+    JEDI = 1983
+
+
+py_enum = Enum("Episode", PyEnum)
+
+
+def test_enum_is_resolved_from_internal_value():
+    query = ResolverMap("Query")
+    query.field("testEnum")(lambda *_: PyEnum.NEWHOPE)
+
+    schema = make_executable_schema([enum_definition, enum_field], [query, py_enum])
     result = graphql_sync(schema, "{ testEnum }")
     assert result.data["testEnum"] == TEST_VALUE
 
 
 def test_enum_arg_is_transformed_to_internal_value():
     query = ResolverMap("Query")
-    query.field("testEnum")(lambda *_, value: value == TEST_INTERNAL_VALUE)
+    query.field("testEnum")(lambda *_, value: value == PyEnum.NEWHOPE)
 
-    schema = make_executable_schema([enum_definition, enum_param], [query, custom_enum])
+    schema = make_executable_schema([enum_definition, enum_param], [query, py_enum])
+    result = graphql_sync(schema, "{ testEnum(value: %s) }" % TEST_VALUE)
+    assert result.data["testEnum"] is True
+
+
+class IntEnum(enum.IntEnum):
+    NEWHOPE = 1977
+    EMPIRE = 1980
+    JEDI = 1983
+
+
+int_enum = Enum("Episode", IntEnum)
+
+
+def test_int_enum_is_resolved_from_internal_value():
+    query = ResolverMap("Query")
+    query.field("testEnum")(lambda *_: IntEnum.NEWHOPE)
+
+    schema = make_executable_schema([enum_definition, enum_field], [query, int_enum])
+    result = graphql_sync(schema, "{ testEnum }")
+    assert result.data["testEnum"] == TEST_VALUE
+
+
+def test_int_enum_arg_is_transformed_to_internal_value():
+    query = ResolverMap("Query")
+    query.field("testEnum")(lambda *_, value: value == IntEnum.NEWHOPE)
+
+    schema = make_executable_schema([enum_definition, enum_param], [query, int_enum])
     result = graphql_sync(schema, "{ testEnum(value: %s) }" % TEST_VALUE)
     assert result.data["testEnum"] is True

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -63,7 +63,7 @@ def test_unsuccessfull_invalid_enum_value_passed_as_argument():
     schema = make_executable_schema([enum_definition, enum_param], query)
     result = graphql_sync(schema, "{ testEnum(value: %s) }" % INVALID_VALUE)
     assert result.errors is not None
-    
+
 
 @pytest.fixture
 def schema_with_enum():
@@ -82,20 +82,15 @@ def test_attempt_bind_custom_enum_to_wrong_schema_type_raises_error(schema_with_
         enum.bind_to_schema(schema_with_enum)
 
 
-def test_attempt_bind_custom_enum_to_schema_enum_missing_value_raises_error(schema_with_enum):
+def test_attempt_bind_custom_enum_to_schema_enum_missing_value_raises_error(
+    schema_with_enum
+):
     enum = Enum("Episode", {"JARJAR": 1999})
     with pytest.raises(ValueError):
         enum.bind_to_schema(schema_with_enum)
 
 
-custom_enum = Enum(
-    "Episode",
-    {
-        "NEWHOPE": 1977,
-        "EMPIRE": 1980,
-        "JEDI": 1983,
-    },
-)
+custom_enum = Enum("Episode", {"NEWHOPE": 1977, "EMPIRE": 1980, "JEDI": 1983})
 
 TEST_INTERNAL_VALUE = 1977
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -1,6 +1,8 @@
-from graphql import graphql_sync
+import pytest
 
-from ariadne import ResolverMap, make_executable_schema
+from graphql import graphql_sync, build_schema
+
+from ariadne import Enum, ResolverMap, make_executable_schema
 
 enum_definition = """
     enum Episode {
@@ -45,7 +47,7 @@ enum_param = """
 """
 
 
-def test_succesfull_enum_value_passed_as_argument():
+def test_successfull_enum_value_passed_as_argument():
     query = ResolverMap("Query")
     query.field("testEnum")(lambda *_, value: True)
 
@@ -54,10 +56,63 @@ def test_succesfull_enum_value_passed_as_argument():
     assert result.errors is None, result.errors
 
 
-def test_unsuccesfull_invalid_enum_value_passed_as_argument():
+def test_unsuccessfull_invalid_enum_value_passed_as_argument():
     query = ResolverMap("Query")
     query.field("testEnum")(lambda *_, value: True)
 
     schema = make_executable_schema([enum_definition, enum_param], query)
     result = graphql_sync(schema, "{ testEnum(value: %s) }" % INVALID_VALUE)
     assert result.errors is not None
+    
+
+@pytest.fixture
+def schema_with_enum():
+    return build_schema("\n\n".join((enum_definition, enum_field)))
+
+
+def test_attempt_bind_custom_enum_to_undefined_type_raises_error(schema_with_enum):
+    enum = Enum("Undefined", {})
+    with pytest.raises(ValueError):
+        enum.bind_to_schema(schema_with_enum)
+
+
+def test_attempt_bind_custom_enum_to_wrong_schema_type_raises_error(schema_with_enum):
+    enum = Enum("Query", {})
+    with pytest.raises(ValueError):
+        enum.bind_to_schema(schema_with_enum)
+
+
+def test_attempt_bind_custom_enum_to_schema_enum_missing_value_raises_error(schema_with_enum):
+    enum = Enum("Episode", {"JARJAR": 1999})
+    with pytest.raises(ValueError):
+        enum.bind_to_schema(schema_with_enum)
+
+
+custom_enum = Enum(
+    "Episode",
+    {
+        "NEWHOPE": 1977,
+        "EMPIRE": 1980,
+        "JEDI": 1983,
+    },
+)
+
+TEST_INTERNAL_VALUE = 1977
+
+
+def test_enum_is_resolved_from_internal_value():
+    query = ResolverMap("Query")
+    query.field("testEnum")(lambda *_: TEST_INTERNAL_VALUE)
+
+    schema = make_executable_schema([enum_definition, enum_field], [query, custom_enum])
+    result = graphql_sync(schema, "{ testEnum }")
+    assert result.data["testEnum"] == TEST_VALUE
+
+
+def test_enum_arg_is_transformed_to_internal_value():
+    query = ResolverMap("Query")
+    query.field("testEnum")(lambda *_, value: value == TEST_INTERNAL_VALUE)
+
+    schema = make_executable_schema([enum_definition, enum_param], [query, custom_enum])
+    result = graphql_sync(schema, "{ testEnum(value: %s) }" % TEST_VALUE)
+    assert result.data["testEnum"] is True

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -58,7 +58,7 @@ def test_successful_enum_value_passed_as_argument():
     assert result.errors is None, result.errors
 
 
-def test_unsuccessfull_invalid_enum_value_passed_as_argument():
+def test_unsuccessful_invalid_enum_value_passed_as_argument():
     query = ResolverMap("Query")
     query.field("testEnum")(lambda *_, value: True)
 

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -49,7 +49,7 @@ enum_param = """
 """
 
 
-def test_successfull_enum_value_passed_as_argument():
+def test_successful_enum_value_passed_as_argument():
     query = ResolverMap("Query")
     query.field("testEnum")(lambda *_, value: True)
 


### PR DESCRIPTION
This PR adds `Enum` *bindable* that takes name of enum in schema and dict of mappings, enabling easy transformation of enum values between GraphQL and internal representation:

```
role = Enum(
    "role",
    {
        "ADMIN": 1,
        "MODERATOR": 2,
        "MVP": 4,
        "REGULAR" 5,
        "PROBATION": 6,
    }
)
```

Fixes #39 