### PR TITLE
Spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Documentation is available [here](https://ariadne.readthedocs.io/).
 - Defining schema using SDL strings.
 - Loading schema from `.graphql` files.
 - WSGI middleware for implementing GraphQL in existing sites.
-- Opt-in automatic resolvers mapping between `pascalCase` and `snake_case`.
+- Opt-in automatic resolvers mapping between `camelCase` and `snake_case`.
 - Build-in simple synchronous dev server for quick GraphQL experimentation and GraphQL Playground.
 - Support for [Apollo GraphQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo).
 - GraphQL syntax validation via `gql()` helper function. Also provides colorization if Apollo GraphQL extension is installed.

--- a/docs/enums.rst
+++ b/docs/enums.rst
@@ -77,9 +77,9 @@ Imagine posts on social site that can have weights like "standard", "pinned" and
         PROMOTED
     }
 
-In database, the application may store those weights as integers from 0 to 2. Normally, you would have to implement custom resolver transforming GraphQL representation to the integer but, like with scalars, you would have to remember to use this boiler plate on every use.
+In the database, the application may store those weights as integers from 0 to 2. Normally, you would have to implement a custom resolver transforming GraphQL representation to the integer but, like with scalars, you would have to remember to use this boiler plate on every use.
 
-Ariadne provides ``Enum`` utility class thats allows you to delegate this task to GraphQL server::
+Ariadne provides an ``Enum`` utility class thats allows you to delegate this task to GraphQL server::
 
     import enum
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Features
 - Defining schema using SDL strings.
 - Loading schema from ``.graphql`` files.
 - WSGI middleware for implementing GraphQL in existing sites.
-- Opt-in automatic resolvers mapping between `pascalCase` and ``snake_case``.
+- Opt-in automatic resolvers mapping between `camelCase` and ``snake_case``.
 - Build-in simple synchronous dev server for quick GraphQL experimentation and GraphQL Playground.
 - Support for `Apollo GraphQL extension for Visual Studio Code <https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo>`_.
 - GraphQL syntax validation via ``gql()`` helper function. Also provides colorization if Apollo GraphQL extension is installed.

--- a/tests/test_case_convertion_util.py
+++ b/tests/test_case_convertion_util.py
@@ -1,7 +1,7 @@
 from ariadne import convert_camel_case_to_snake
 
 
-def test_snake_case_name_is_not_changed():
+def test_lower_case_name_is_not_changed():
     test_str = "test"
     assert convert_camel_case_to_snake(test_str) == test_str
 
@@ -16,21 +16,21 @@ def test_three_words_snake_case_name_is_not_changed():
     assert convert_camel_case_to_snake(test_str) == test_str
 
 
-def test_camel_case_name_is_lowercased():
+def test_pascal_case_name_is_lowercased():
     assert convert_camel_case_to_snake("Test") == "test"
 
 
-def test_two_words_camel_case_name_is_converted():
+def test_two_words_pascal_case_name_is_converted():
     assert convert_camel_case_to_snake("TestName") == "test_name"
 
 
-def test_two_words_pascal_case_name_is_converted():
+def test_two_words_camel_case_name_is_converted():
     assert convert_camel_case_to_snake("testName") == "test_name"
 
 
-def test_three_words_camel_case_name_is_converted():
+def test_three_words_pascal_case_name_is_converted():
     assert convert_camel_case_to_snake("TestComplexName") == "test_complex_name"
 
 
-def test_three_words_pascal_case_name_is_converted():
+def test_three_words_camel_case_name_is_converted():
     assert convert_camel_case_to_snake("testComplexName") == "test_complex_name"

--- a/tests/test_fallback_resolvers.py
+++ b/tests/test_fallback_resolvers.py
@@ -12,31 +12,31 @@ def schema():
                 hello: Boolean
                 snake_case: Boolean
                 Camel: Boolean
-                pascalCase: Boolean
+                camelCase: Boolean
             }
         """
     )
 
 
-query = "{ hello snake_case Camel pascalCase }"
+query = "{ hello snake_case Camel camelCase }"
 
 
 def test_default_fallback_resolves_fields_by_exact_names(schema):
     fallback_resolvers.bind_to_schema(schema)
-    query_root = {"hello": True, "snake_case": True, "Camel": True, "pascalCase": True}
+    query_root = {"hello": True, "snake_case": True, "Camel": True, "camelCase": True}
     result = graphql_sync(schema, query, root_value=query_root)
     assert result.data == query_root
 
 
 def test_default_fallback_is_not_converting_field_name_case_to_snake_case(schema):
     fallback_resolvers.bind_to_schema(schema)
-    query_root = {"hello": True, "snake_case": True, "camel": True, "pascal_case": True}
+    query_root = {"hello": True, "snake_case": True, "camel": True, "camel_case": True}
     result = graphql_sync(schema, query, root_value=query_root)
     assert result.data == {
         "hello": True,
         "snake_case": True,
         "Camel": None,
-        "pascalCase": None,
+        "camelCase": None,
     }
 
 
@@ -50,37 +50,37 @@ def test_default_fallback_is_not_replacing_already_set_resolvers(schema):
     )
     resolvers_map.bind_to_schema(schema)
     fallback_resolvers.bind_to_schema(schema)
-    query_root = {"hello": True, "snake_case": True, "camel": True, "pascal_case": True}
+    query_root = {"hello": True, "snake_case": True, "camel": True, "camel_case": True}
     result = graphql_sync(schema, query, root_value=query_root)
     assert result.data == {
         "hello": False,
         "snake_case": False,
         "Camel": None,
-        "pascalCase": None,
+        "camelCase": None,
     }
 
 
 def test_snake_case_fallback_resolves_fields_names_to_snake_case_counterparts(schema):
     snake_case_fallback_resolvers.bind_to_schema(schema)
-    query_root = {"hello": True, "snake_case": True, "camel": True, "pascal_case": True}
+    query_root = {"hello": True, "snake_case": True, "camel": True, "camel_case": True}
     result = graphql_sync(schema, query, root_value=query_root)
     assert result.data == {
         "hello": True,
         "snake_case": True,
         "Camel": True,
-        "pascalCase": True,
+        "camelCase": True,
     }
 
 
 def test_snake_case_fallback_is_not_resolving_fields_by_exact_names(schema):
     snake_case_fallback_resolvers.bind_to_schema(schema)
-    query_root = {"hello": True, "snake_case": True, "Camel": True, "pascalCase": True}
+    query_root = {"hello": True, "snake_case": True, "Camel": True, "camelCase": True}
     result = graphql_sync(schema, query, root_value=query_root)
     assert result.data == {
         "hello": True,
         "snake_case": True,
         "Camel": None,
-        "pascalCase": None,
+        "camelCase": None,
     }
 
 
@@ -94,11 +94,11 @@ def test_snake_case_fallback_is_not_replacing_already_set_resolvers(schema):
     )
     resolvers_map.bind_to_schema(schema)
     snake_case_fallback_resolvers.bind_to_schema(schema)
-    query_root = {"hello": True, "snake_case": True, "camel": True, "pascal_case": True}
+    query_root = {"hello": True, "snake_case": True, "camel": True, "camel_case": True}
     result = graphql_sync(schema, query, root_value=query_root)
     assert result.data == {
         "hello": False,
         "snake_case": True,
         "Camel": False,
-        "pascalCase": True,
+        "camelCase": True,
     }


### PR DESCRIPTION
This PR fixes the `PascalCase` & `camelCase` mixup in docs and tests and adds spellchecking pass on the enum docs.