### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ def resolve_people(*_):
 
 person = ResolverMap("Person")
 
-@person.field("fullname")
+@person.field("fullName")
 def resolve_person_fullname(person, *_):
     return "%s %s" % (person["firstName"], person["lastName"])
 


### PR DESCRIPTION
`type_defs` defines a `fullName` field, but the resolver field is named `fullname` (no capital N), raising a ValueError. This PR fixes the typo and makes the example run.