### PR TITLE
Add subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.3.0 (UNRELEASED)
 
 - Added `Enum` type for mapping enum variables to internal representation used in application.
+- Added support for subscriptions.
 
 ## 0.2.0 (2019-01-07)
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Documentation is available [here](https://ariadne.readthedocs.io/).
 - Compatibility with GraphQL.js version 14.0.2.
 - Queries, mutations and input types.
 - Asynchronous resolvers and query execution.
+- Subscriptions.
 - Custom scalars and enums.
 - Defining schema using SDL strings.
 - Loading schema from `.graphql` files.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Documentation is available [here](https://ariadne.readthedocs.io/).
 - Support for [Apollo GraphQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo).
 - GraphQL syntax validation via `gql()` helper function. Also provides colorization if Apollo GraphQL extension is installed.
 
-Following features should work but are not tested and documented: unions, interfaces and subscriptions.
+Following features should work but are not tested and documented: unions and interfaces.
 
 
 ## Installation

--- a/ariadne/resolvers.py
+++ b/ariadne/resolvers.py
@@ -44,29 +44,27 @@ class ResolverMap(Bindable):
         return register_resolver
 
     @overload
-    def subscription(self, name: str) -> Callable[[Subscriber], Subscriber]:
+    def source(self, name: str) -> Callable[[Subscriber], Subscriber]:
         pass  # pragma: no cover
 
     @overload
-    def subscription(  # pylint: disable=function-redefined
-        self, name: str, *, subscriber: Subscriber
+    def source(  # pylint: disable=function-redefined
+        self, name: str, *, generator: Subscriber
     ) -> Subscriber:  # pylint: disable=function-redefined
         pass  # pragma: no cover
 
-    def subscription(
-        self, name, *, subscriber=None
-    ):  # pylint: disable=function-redefined
-        if not subscriber:
+    def source(self, name, *, generator=None):  # pylint: disable=function-redefined
+        if not generator:
             return self.create_register_subscriber(name)
-        self._subscribers[name] = subscriber
-        return subscriber
+        self._subscribers[name] = generator
+        return generator
 
     def create_register_subscriber(
         self, name: str
     ) -> Callable[[Subscriber], Subscriber]:
-        def register_subscriber(f: Subscriber) -> Subscriber:
-            self._subscribers[name] = f
-            return f
+        def register_subscriber(generator: Subscriber) -> Subscriber:
+            self._subscribers[name] = generator
+            return generator
 
         return register_subscriber
 

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable
+from typing import Any, AsyncGenerator, Callable
 from typing_extensions import Protocol
 
 from graphql.type import GraphQLSchema
@@ -13,5 +13,6 @@ class Bindable(Protocol):
 # but this is not achieveable with python types yet:
 # https://github.com/mirumee/ariadne/pull/79
 Resolver = Callable[..., Any]
+Subscriber = Callable[..., AsyncGenerator]
 
 ScalarOperation = Callable[[Any], Any]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,6 +45,7 @@ Table of contents
    error-messaging
    scalars
    enums
+   subscriptions
    modularization
    wsgi-middleware
    custom-server

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Features
 - Support for `Apollo GraphQL extension for Visual Studio Code <https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo>`_.
 - GraphQL syntax validation via ``gql()`` helper function. Also provides colorization if Apollo GraphQL extension is installed.
 
-Following features should work but are not tested and documented: unions, interfaces and subscriptions.
+Following features should work but are not tested and documented: unions and interfaces.
 
 
 Requirements and installation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,7 @@ Features
 - Compatibility with GraphQL.js version 14.0.2.
 - Queries, mutations and input types.
 - Asynchronous resolvers and query execution.
+- Subscriptions.
 - Custom scalars and enums.
 - Defining schema using SDL strings.
 - Loading schema from ``.graphql`` files.

--- a/docs/mutations.rst
+++ b/docs/mutations.rst
@@ -29,9 +29,9 @@ Let's define the basic schema that implements a simple authentication mechanism 
 
 In this example we have the following elements:
 
-``Query`` type with single field: boolean for checking if we are authenticated or not. It may appear superficial for the sake of this example, *but Ariadne requires* that your GraphQL API always defines ``Query`` type.
+The ``Query`` type with single field: boolean for checking if we are authenticated or not. It may appear superficial for the sake of this example, *but Ariadne requires* that your GraphQL API always defines ``Query`` type.
 
-``Mutation`` type with two mutations: ``login`` mutation that requires username and password strings and returns bool with status, and ``logout`` that takes no arguments and just returns status.
+The ``Mutation`` type with two mutations: ``login`` mutation that requires username and password strings and returns bool with status, and ``logout`` that takes no arguments and just returns status.
 
 
 Writing resolvers

--- a/docs/resolvers.rst
+++ b/docs/resolvers.rst
@@ -1,3 +1,5 @@
+.. _resolvers:
+
 Resolvers
 =========
 

--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -7,10 +7,12 @@ This is where the ``Subscription`` type comes useful. It's similar to ``Query`` 
 
 .. warning::
    Because of their nature, subscriptions are only possible to implement in asynchronous servers that implement the WebSockets protocol.
-   
+
    *WSGI*-based servers (including Django) are synchronous in nature and *unable* to handle WebSockets which makes them incapable of implementing subscriptions.
 
    If you wish to use subscriptions with Django, consider wrapping your Django application in a Django Channels container and using Ariadne as an *ASGI* server.
+
+   At this time, Ariadne's ``start_simple_server`` is based on WSGI and does not support subscriptions.
 
 
 Defining subscriptions

--- a/docs/subscriptions.rst
+++ b/docs/subscriptions.rst
@@ -1,0 +1,75 @@
+Subscriptions
+=============
+
+Let's introduce a third type of operation. While queries offer a way to query a server once, subscriptions offer a way for the server to notify the client each time new data is available and that no other data will be available for the given request.
+
+This is where the ``Subscription`` type comes useful. It's similar to ``Query`` but as each subscription remains an open channel you can send anywhere from zero to millions of responses over its lifetime.
+
+.. warning::
+   Because of their nature, subscriptions are only possible to implement in asynchronous servers that implement the WebSockets protocol.
+   
+   *WSGI*-based servers (including Django) are synchronous in nature and *unable* to handle WebSockets which makes them incapable of implementing subscriptions.
+
+   If you wish to use subscriptions with Django, consider wrapping your Django application in a Django Channels container and using Ariadne as an *ASGI* server.
+
+
+Defining subscriptions
+----------------------
+
+In schema definition subscriptions look similar to queries::
+
+    type_def = """
+        type Query {}
+
+        type Subscription {
+            counter: Int!
+        }
+    """
+
+This example contains:
+
+The ``Query`` type with no fields. Ariadne requires you to always have a ``Query`` type.
+
+The ``Subscription`` type with a single field: ``counter`` that returns a number.
+
+When defining subscriptions you can use all of the features of the schema such as arguments, input and output types.
+
+Writing subscriptions
+---------------------
+
+Subscriptions are more complex than queries as they require us to provide two functions for each field:
+
+A ``resolver`` that tells the server how to send data to the client. This is similar to the ref:`resolvers we wrote earlier <resolvers>`.
+
+A ``subscriber`` which is a function that returns the source of data we're going to send to the client. The source has to implement the ``AsyncGenerator`` protocol. Make sure you understand how asynchronous generators work before attempting to use subscriptions.
+
+The signatures are as follows::
+
+    def counter_resolver(
+        count: int, info: GraphQLResolveInfo
+    ) -> int:
+        return count
+
+    async def counter_subscriber(
+        obj: Any, info: GraphQLResolveInfo
+    ) -> AsyncGenerator[int, None]:
+        for i in range(1, 6):
+            await asyncio.sleep(1)
+            yield i
+
+Note that the resolver consumes the same type (in this case ``int``) that the generator yields. Each time our source yields a response, its getting sent to our resolver. The above implementation counts from one to five, each time waiting for one second before yielding a value. After the last value is yielded the generator returns and the server tells the client that no more data will be available and the subscription is complete.
+
+We can map these functions to subscription fields using the ``ResolverMap`` like we did for queries and mutations::
+
+    from ariadne import ResolverMap
+    from . import counter_subscriptions
+
+    sub_map = ResolverMap("Subscription")
+    sub_map.field(
+        "counter",
+        resolver=counter_subscriptions.counter_resolver
+    )
+    sub_map.subscription(
+        "counter",
+        subscriber=counter_subscriptions.counter_subscriber
+    )

--- a/tests/test_resolver_map.py
+++ b/tests/test_resolver_map.py
@@ -77,9 +77,7 @@ def test_subscription_method_sets_the_field_subscriber(schema):
         yield "test"
 
     sub = ResolverMap("Subscription")
-    sub.source(  # pylint: disable=unexpected-keyword-arg
-        "message", generator=source
-    )
+    sub.source("message", generator=source)  # pylint: disable=unexpected-keyword-arg
     sub.bind_to_schema(schema)
     field = schema.type_map.get("Subscription").fields["message"]
     assert field.subscribe is source
@@ -101,8 +99,6 @@ def test_attempt_bind_subscription_to_undefined_field_raises_error(schema):
         yield "test"
 
     sub_map = ResolverMap("Subscription")
-    sub_map.source(  # pylint: disable=unexpected-keyword-arg
-        "fake", generator=source
-    )
+    sub_map.source("fake", generator=source)  # pylint: disable=unexpected-keyword-arg
     with pytest.raises(ValueError):
         sub_map.bind_to_schema(schema)

--- a/tests/test_resolver_map.py
+++ b/tests/test_resolver_map.py
@@ -74,7 +74,7 @@ def test_alias_method_creates_resolver_for_specified_attribute(schema):
 
 def test_subscription_method_sets_the_field_subscriber(schema):
     async def source(*_):
-        yield "test"
+        yield "test"  # pragma: no cover
 
     sub = ResolverMap("Subscription")
     sub.source("message", generator=source)  # pylint: disable=unexpected-keyword-arg
@@ -85,7 +85,7 @@ def test_subscription_method_sets_the_field_subscriber(schema):
 
 def test_subscription_method_works_as_decorator(schema):
     async def source(*_):
-        yield "test"
+        yield "test"  # pragma: no cover
 
     sub = ResolverMap("Subscription")
     sub.source("message")(source)
@@ -96,7 +96,7 @@ def test_subscription_method_works_as_decorator(schema):
 
 def test_attempt_bind_subscription_to_undefined_field_raises_error(schema):
     async def source(*_):
-        yield "test"
+        yield "test"  # pragma: no cover
 
     sub_map = ResolverMap("Subscription")
     sub_map.source("fake", generator=source)  # pylint: disable=unexpected-keyword-arg

--- a/tests/test_resolver_map.py
+++ b/tests/test_resolver_map.py
@@ -12,6 +12,10 @@ def schema():
                 hello: String
             }
 
+            type Subscription {
+                message: String!
+            }
+
             scalar Date
         """
     )
@@ -66,3 +70,23 @@ def test_alias_method_creates_resolver_for_specified_attribute(schema):
     result = graphql_sync(schema, "{ hello }", root_value={"test": "World"})
     assert result.errors is None
     assert result.data == {"hello": "World"}
+
+
+def test_subscription_method_sets_the_field_subscriber(schema):
+    sub = ResolverMap("Subscription")
+    subscribe = lambda *_: ...
+    sub.subscription(  # pylint: disable=unexpected-keyword-arg
+        "message", subscriber=subscribe
+    )
+    sub.bind_to_schema(schema)
+    field = schema.type_map.get("Subscription").fields["message"]
+    assert field.subscribe is subscribe
+
+
+def test_subscription_method_works_as_decorator(schema):
+    sub = ResolverMap("Subscription")
+    subscribe = lambda *_: ...
+    sub.subscription("message")(subscribe)
+    sub.bind_to_schema(schema)
+    field = schema.type_map.get("Subscription").fields["message"]
+    assert field.subscribe is subscribe


### PR DESCRIPTION
As simple as that. Subscriptions.

Bear in mind that as long as the example server is synchronous, the subscriptions won't work with the example server.

I'm not a fan of the API we're ending up with for the `ResolverMap`.

I think I'd prefer:

```python
sub_map = ResolverMap("Subscription")

@sub_map.add_field("counter")
def counter(count, info):
    return count

@sub_map.add_source("counter")
async def tick(root, info):
    ...
```

They also look better when used as non-decorators:

```python
sub_map.add_field("counter", resolver=counter)
sub_map.add_source("counter", generator=tick)
```