### PR TITLE
Add unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 - Added `Enum` type for mapping enum variables to internal representation used in application.
 - Added support for subscriptions.
-- Updated Playground to 1.8.7
-- Split `GraphQLMiddleware` into two classes and moved it to `ariadne.wsgi`
-- Made users responsible for calling `make_executable_schema`
+- Updated Playground to 1.8.7.
+- Split `GraphQLMiddleware` into two classes and moved it to `ariadne.wsgi`.
+- Made users responsible for calling `make_executable_schema`.
+- Added support for unions.
 
 ## 0.2.0 (2019-01-07)
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Documentation is available [here](https://ariadne.readthedocs.io/).
 - Asynchronous resolvers and query execution.
 - Subscriptions.
 - Custom scalars and enums.
+- Unions.
 - Defining schema using SDL strings.
 - Loading schema from `.graphql` files.
 - WSGI middleware for implementing GraphQL in existing sites.
@@ -31,7 +32,7 @@ Documentation is available [here](https://ariadne.readthedocs.io/).
 - Support for [Apollo GraphQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo).
 - GraphQL syntax validation via `gql()` helper function. Also provides colorization if Apollo GraphQL extension is installed.
 
-Following features should work but are not tested and documented: unions and interfaces.
+Following features should work but are not tested and documented: interfaces.
 
 
 ## Installation

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -12,6 +12,7 @@ from .resolvers import (
 )
 from .scalars import Scalar
 from .simple_server import start_simple_server
+from .unions import Union
 from .utils import convert_camel_case_to_snake, gql
 
 __all__ = [
@@ -20,6 +21,7 @@ __all__ = [
     "ResolverMap",
     "Scalar",
     "SnakeCaseFallbackResolversSetter",
+    "Union",
     "convert_camel_case_to_snake",
     "default_resolver",
     "fallback_resolvers",

--- a/ariadne/unions.py
+++ b/ariadne/unions.py
@@ -6,9 +6,9 @@ from .types import Bindable, Resolver
 
 
 class Union(Bindable):
-    _resolve_type: Resolver
+    _resolve_type: Optional[Resolver]
 
-    def __init__(self, name: str, *, type_resolver: Optional[Resolver] = None) -> None:
+    def __init__(self, name: str, type_resolver: Optional[Resolver] = None) -> None:
         self.name = name
         self._resolve_type = type_resolver
 

--- a/ariadne/unions.py
+++ b/ariadne/unions.py
@@ -1,0 +1,33 @@
+from typing import Optional
+
+from graphql.type import GraphQLUnionType, GraphQLSchema
+
+from .types import Bindable, Resolver
+
+
+class Union(Bindable):
+    _resolve_type: Resolver
+
+    def __init__(self, name: str, *, type_resolver: Optional[Resolver] = None) -> None:
+        self.name = name
+        self._resolve_type = type_resolver
+
+    def set_type_resolver(self, type_resolver: Resolver) -> Resolver:
+        self._resolve_type = type_resolver
+        return type_resolver
+
+    type_resolver = set_type_resolver  # Alias for non-prefixed use in decorator
+
+    def bind_to_schema(self, schema: GraphQLSchema) -> None:
+        graphql_type = schema.type_map.get(self.name)
+        self.validate_graphql_type(graphql_type)
+        graphql_type.resolve_type = self._resolve_type
+
+    def validate_graphql_type(self, graphql_type: str) -> None:
+        if not graphql_type:
+            raise ValueError("Type %s is not defined in the schema" % self.name)
+        if not isinstance(graphql_type, GraphQLUnionType):
+            raise ValueError(
+                "%s is defined in the schema, but it is instance of %s (expected %s)"
+                % (self.name, type(graphql_type).__name__, GraphQLUnionType.__name__)
+            )

--- a/ariadne/unions.py
+++ b/ariadne/unions.py
@@ -12,11 +12,9 @@ class Union(Bindable):
         self.name = name
         self._resolve_type = type_resolver
 
-    def set_type_resolver(self, type_resolver: Resolver) -> Resolver:
+    def type_resolver(self, type_resolver: Resolver) -> Resolver:
         self._resolve_type = type_resolver
         return type_resolver
-
-    type_resolver = set_type_resolver  # Alias for non-prefixed use in decorator
 
     def bind_to_schema(self, schema: GraphQLSchema) -> None:
         graphql_type = schema.type_map.get(self.name)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Features
 - Asynchronous resolvers and query execution.
 - Subscriptions.
 - Custom scalars and enums.
+- Unions.
 - Defining schema using SDL strings.
 - Loading schema from ``.graphql`` files.
 - WSGI middleware for implementing GraphQL in existing sites.
@@ -23,7 +24,7 @@ Features
 - Support for `Apollo GraphQL extension for Visual Studio Code <https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo>`_.
 - GraphQL syntax validation via ``gql()`` helper function. Also provides colorization if Apollo GraphQL extension is installed.
 
-Following features should work but are not tested and documented: unions and interfaces.
+Following features should work but are not tested and documented: interfaces.
 
 
 Requirements and installation
@@ -46,6 +47,7 @@ Table of contents
    error-messaging
    scalars
    enums
+   unions
    subscriptions
    modularization
    local-development

--- a/docs/unions.rst
+++ b/docs/unions.rst
@@ -1,9 +1,9 @@
 Union types
 ===========
 
-When designing your API you may run into a situation where you want your field to resolve to one of few possible types. It may be an ``error`` field that can resolve to one of many error types, or an activity feed made of different types.
+When designing your API, you may run into a situation where you want your field to resolve to one of a few possible types. It may be an ``error`` field that can resolve to one of many error types, or an activity feed made up of different types.
 
-Most obvious solution may be creating custom "intermediary" type that would define dedicated fields to different types::
+The most obvious solution may be creating a custom "intermediary" type that would define dedicated fields to different types::
 
     type MutationPayload {
         status: Boolean!
@@ -18,13 +18,13 @@ Most obvious solution may be creating custom "intermediary" type that would defi
         user: User
     }
 
-GraphQL provides dedicated solution to this problem in the form of dedicated `Union` type.
+GraphQL provides a dedicated solution to this problem in the form of dedicated ``Union`` type.
 
 
 Union example
 -------------
 
-Consider earlier error example. Union representing one of possible three error types can be defined in schema like this::
+Consider an earlier error example. The union representing one of a possible three error types can be defined in schema like this::
 
     union Error = NotFoundError | AccessError | ValidationError
 
@@ -36,7 +36,7 @@ This ``Error`` type can be used just like any other type::
         user: User
     }
 
-Your union will also need a special resolver named *type resolver*. This resolver will we called with an object returned from field resolver and current context, and should return string containing name of an GraphQL type, or ``None`` if received type is incorrect::
+Your union will also need a special resolver named *type resolver*. This resolver will we called with an object returned from a field resolver and current context, and should return a string containing the name of an GraphQL type, or ``None`` if received type is incorrect::
 
     def resolve_error_type(obj, *_):
         if isinstance(obj, ValidationError):
@@ -48,7 +48,7 @@ Your union will also need a special resolver named *type resolver*. This resolve
 .. note::
    Returning ``None`` from this resolver will result in ``null`` being returned for this field in your query's result.
 
-Ariadne provides special ``Union`` class that allows you to bind this function to Union in your schema::
+Ariadne relies on dedicated ``Union`` object for bindinding this function to Union in your schema::
 
     from ariadne import Union
 
@@ -58,7 +58,7 @@ Ariadne provides special ``Union`` class that allows you to bind this function t
     def resolve_error_type(obj, *_):
         ...
 
-If this function is already defined elsewhere (eg. 3rd party package), you can instantiate the ``Union`` with it as second argument::
+If this function is already defined elsewhere (e.g. 3rd party package), you can instantiate the ``Union`` with it as second argument::
 
     from ariadne import Union
     from .graphql import resolve_error_type
@@ -73,7 +73,7 @@ Lastly, your ``Union`` instance should be passed to ``make_executable_schema`` t
 ``__typename`` field
 --------------------
 
-Every type in GraphQL has special ``__typename`` field that is resolved to string containing type's name.
+Every type in GraphQL has a special ``__typename`` field that is resolved to a string containing the type's name.
 
 Including this field in your query may simplify implementation of result handling logic in your client::
 
@@ -92,7 +92,7 @@ Including this field in your query may simplify implementation of result handlin
         }
     }
 
-Assuming that feed is a list, query could produce following response::
+Assuming that the feed is a list, the query could produce the following response::
 
     {
         "data": {

--- a/docs/unions.rst
+++ b/docs/unions.rst
@@ -1,0 +1,124 @@
+Union types
+===========
+
+When designing your API you may run into a situation where you want your field to resolve to one of few possible types. It may be an ``error`` field that can resolve to one of many error types, or an activity feed made of different types.
+
+Most obvious solution may be creating custom "intermediary" type that would define dedicated fields to different types::
+
+    type MutationPayload {
+        status: Boolean!
+        validationError: ValidationError
+        permissionError: AccessError
+        user: User
+    }
+
+    type FeedItem {
+        post: Post
+        image: Image
+        user: User
+    }
+
+GraphQL provides dedicated solution to this problem in the form of dedicated `Union` type.
+
+
+Union example
+-------------
+
+Consider earlier error example. Union representing one of possible three error types can be defined in schema like this::
+
+    union Error = NotFoundError | AccessError | ValidationError
+
+This ``Error`` type can be used just like any other type::
+
+    type MutationPayload {
+        status: Boolean!
+        error: Error
+        user: User
+    }
+
+Your union will also need a special resolver named *type resolver*. This resolver will we called with an object returned from field resolver and current context, and should return string containing name of an GraphQL type, or ``None`` if received type is incorrect::
+
+    def resolve_error_type(obj, *_):
+        if isinstance(obj, ValidationError):
+            return "ValidationError"
+        if isinstance(obj, AccessError):
+            return "AccessError"
+        return None
+
+.. note::
+   Returning ``None`` from this resolver will result in ``null`` being returned for this field in your query's result.
+
+Ariadne provides special ``Union`` class that allows you to bind this function to Union in your schema::
+
+    from ariadne import Union
+
+    error = Union("Error")
+
+    @error.type_resolver
+    def resolve_error_type(obj, *_):
+        ...
+
+If this function is already defined elsewhere (eg. 3rd party package), you can instantiate the ``Union`` with it as second argument::
+
+    from ariadne import Union
+    from .graphql import resolve_error_type
+
+    error = Union("Error", resolve_error_type)
+
+Lastly, your ``Union`` instance should be passed to ``make_executable_schema`` together will other resolvers::
+
+    schema = make_executable_schema(type_defs, [query, error])
+
+
+``__typename`` field
+--------------------
+
+Every type in GraphQL has special ``__typename`` field that is resolved to string containing type's name.
+
+Including this field in your query may simplify implementation of result handling logic in your client::
+
+    query getFeed {
+        feed {
+            __typename
+            ... on Post {
+                text
+            }
+            ... on Image {
+                url
+            }
+            ... on User {
+                username
+            }
+        }
+    }
+
+Assuming that feed is a list, query could produce following response::
+
+    {
+        "data": {
+            "feed": [
+                {
+                    "__typename": "User",
+                    "username": "Bob"
+                },
+                {
+                    "__typename": "User",
+                    "username": "Aerith"
+                },
+                {
+                    "__typename": "Image",
+                    "url": "http://placekitten.com/200/300"
+                },
+                {
+                    "__typename": "Post",
+                    "text": "Hello world!"
+                },
+                {
+                    "__typename": "Image",
+                    "url": "http://placekitten.com/200/300"
+                }
+            ]
+        }
+    }
+
+Client code could check the ``__typename`` value of every item in the feed to decide how it should be displayed in the interface.

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -59,9 +59,9 @@ thread = Mock(title="Thread")
 
 def test_union_type_resolver_may_be_set_on_initialization():
     query = ResolverMap("Query")
-    query.field(
+    query.field(  # pylint: disable=unexpected-keyword-arg
         "item", resolver=lambda *_: user
-    )  # pylint: disable=unexpected-keyword-arg
+    )
 
     union = Union("FeedItem", type_resolver=lambda *_: "User")
     schema = make_executable_schema(type_defs, [query, union])
@@ -72,9 +72,9 @@ def test_union_type_resolver_may_be_set_on_initialization():
 
 def test_union_type_resolver_may_be_set_using_decorator():
     query = ResolverMap("Query")
-    query.field(
+    query.field(  # pylint: disable=unexpected-keyword-arg
         "item", resolver=lambda *_: user
-    )  # pylint: disable=unexpected-keyword-arg
+    )
 
     union = Union("FeedItem")
 
@@ -90,9 +90,9 @@ def test_union_type_resolver_may_be_set_using_decorator():
 
 def test_union_type_resolver_may_be_set_using_method():
     query = ResolverMap("Query")
-    query.field(
+    query.field(  # pylint: disable=unexpected-keyword-arg
         "item", resolver=lambda *_: user
-    )  # pylint: disable=unexpected-keyword-arg
+    )
 
     union = Union("FeedItem")
     union.set_type_resolver(lambda *_: "User")
@@ -112,9 +112,9 @@ def resolve_result_type(obj, *_):
 
 def test_result_is_username_if_union_resolves_type_to_user():
     query = ResolverMap("Query")
-    query.field(
+    query.field(  # pylint: disable=unexpected-keyword-arg
         "item", resolver=lambda *_: user
-    )  # pylint: disable=unexpected-keyword-arg
+    )
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])
@@ -124,9 +124,9 @@ def test_result_is_username_if_union_resolves_type_to_user():
 
 def test_result_is_thread_title_if_union_resolves_type_to_thread():
     query = ResolverMap("Query")
-    query.field(
+    query.field(  # pylint: disable=unexpected-keyword-arg
         "item", resolver=lambda *_: thread
-    )  # pylint: disable=unexpected-keyword-arg
+    )
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])
@@ -136,9 +136,9 @@ def test_result_is_thread_title_if_union_resolves_type_to_thread():
 
 def test_result_is_none_if_union_didnt_resolve_the_type():
     query = ResolverMap("Query")
-    query.field(
+    query.field(  # pylint: disable=unexpected-keyword-arg
         "item", resolver=lambda *_: True
-    )  # pylint: disable=unexpected-keyword-arg
+    )
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -1,0 +1,133 @@
+from unittest.mock import Mock
+
+import pytest
+from graphql import build_schema, graphql_sync
+
+from ariadne import ResolverMap, Union, make_executable_schema
+
+type_defs = """
+    union FeedItem = User | Thread
+
+    type User {
+        username: String
+    }
+
+    type Thread {
+        title: String
+    }
+
+    type Query {
+        item: FeedItem
+    }
+"""
+
+
+@pytest.fixture
+def schema():
+    return build_schema(type_defs)
+
+
+def test_attempt_bind_union_to_undefined_type_raises_error(schema):
+    union = Union("Test")
+    with pytest.raises(ValueError):
+        union.bind_to_schema(schema)
+
+
+def test_attempt_bind_union_to_invalid_type_raises_error(schema):
+    union = Union("Query")
+    with pytest.raises(ValueError):
+        union.bind_to_schema(schema)
+
+
+test_query = """
+    {
+        item {
+            ... on User {
+                username
+            }
+            ... on Thread {
+                title
+            }
+        }
+    }
+"""
+
+user = Mock(username="User")
+thread = Mock(title="Thread")
+
+
+def test_union_type_resolver_may_be_set_on_initialization():
+    query = ResolverMap("Query")
+    query.field("item", resolver=lambda *_: user)
+
+    union = Union("FeedItem", type_resolver=lambda *_: "User")
+    schema = make_executable_schema(type_defs, [query, union])
+
+    result = graphql_sync(schema, test_query)
+    assert result.data == {"item": {"username": user.username}}
+
+
+def test_union_type_resolver_may_be_set_using_decorator():
+    query = ResolverMap("Query")
+    query.field("item", resolver=lambda *_: user)
+
+    union = Union("FeedItem")
+
+    @union.type_resolver
+    def resolve_result_type(*_):
+        return "User"
+
+    schema = make_executable_schema(type_defs, [query, union])
+
+    result = graphql_sync(schema, test_query)
+    assert result.data == {"item": {"username": user.username}}
+
+
+def test_union_type_resolver_may_be_set_using_method():
+    query = ResolverMap("Query")
+    query.field("item", resolver=lambda *_: user)
+
+    union = Union("FeedItem")
+    union.set_type_resolver(lambda *_: "User")
+
+    schema = make_executable_schema(type_defs, [query, union])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {"item": {"username": user.username}}
+
+
+def resolve_result_type(obj, *_):
+    if obj == user:
+        return "User"
+    if obj == thread:
+        return "Thread"
+    return None
+
+
+def test_result_is_username_if_union_resolves_type_to_user():
+    query = ResolverMap("Query")
+    query.field("item", resolver=lambda *_: user)
+    union = Union("FeedItem", type_resolver=resolve_result_type)
+
+    schema = make_executable_schema(type_defs, [query, union])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {"item": {"username": user.username}}
+
+
+def test_result_is_thread_title_if_union_resolves_type_to_thread():
+    query = ResolverMap("Query")
+    query.field("item", resolver=lambda *_: thread)
+    union = Union("FeedItem", type_resolver=resolve_result_type)
+
+    schema = make_executable_schema(type_defs, [query, union])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {"item": {"title": thread.title}}
+
+
+def test_result_is_none_if_union_didnt_resolve_the_type():
+    query = ResolverMap("Query")
+    query.field("item", resolver=lambda *_: True)
+    union = Union("FeedItem", type_resolver=resolve_result_type)
+
+    schema = make_executable_schema(type_defs, [query, union])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {"item": None}

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -59,7 +59,9 @@ thread = Mock(title="Thread")
 
 def test_union_type_resolver_may_be_set_on_initialization():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: user)  # pylint: disable=unexpected-keyword-arg
+    query.field(
+        "item", resolver=lambda *_: user
+    )  # pylint: disable=unexpected-keyword-arg
 
     union = Union("FeedItem", type_resolver=lambda *_: "User")
     schema = make_executable_schema(type_defs, [query, union])
@@ -70,7 +72,9 @@ def test_union_type_resolver_may_be_set_on_initialization():
 
 def test_union_type_resolver_may_be_set_using_decorator():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: user)  # pylint: disable=unexpected-keyword-arg
+    query.field(
+        "item", resolver=lambda *_: user
+    )  # pylint: disable=unexpected-keyword-arg
 
     union = Union("FeedItem")
 
@@ -86,7 +90,9 @@ def test_union_type_resolver_may_be_set_using_decorator():
 
 def test_union_type_resolver_may_be_set_using_method():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: user)  # pylint: disable=unexpected-keyword-arg
+    query.field(
+        "item", resolver=lambda *_: user
+    )  # pylint: disable=unexpected-keyword-arg
 
     union = Union("FeedItem")
     union.set_type_resolver(lambda *_: "User")
@@ -106,7 +112,9 @@ def resolve_result_type(obj, *_):
 
 def test_result_is_username_if_union_resolves_type_to_user():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: user)  # pylint: disable=unexpected-keyword-arg
+    query.field(
+        "item", resolver=lambda *_: user
+    )  # pylint: disable=unexpected-keyword-arg
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])
@@ -116,7 +124,9 @@ def test_result_is_username_if_union_resolves_type_to_user():
 
 def test_result_is_thread_title_if_union_resolves_type_to_thread():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: thread)  # pylint: disable=unexpected-keyword-arg
+    query.field(
+        "item", resolver=lambda *_: thread
+    )  # pylint: disable=unexpected-keyword-arg
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])
@@ -126,7 +136,9 @@ def test_result_is_thread_title_if_union_resolves_type_to_thread():
 
 def test_result_is_none_if_union_didnt_resolve_the_type():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: True)  # pylint: disable=unexpected-keyword-arg
+    query.field(
+        "item", resolver=lambda *_: True
+    )  # pylint: disable=unexpected-keyword-arg
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -42,6 +42,7 @@ def test_attempt_bind_union_to_invalid_type_raises_error(schema):
 test_query = """
     {
         item {
+            __typename
             ... on User {
                 username
             }
@@ -63,8 +64,8 @@ def test_union_type_resolver_may_be_set_on_initialization():
     union = Union("FeedItem", type_resolver=lambda *_: "User")
     schema = make_executable_schema(type_defs, [query, union])
 
-    result = graphql_sync(schema, test_query)
-    assert result.data == {"item": {"username": user.username}}
+    result = graphql_sync(schema, "{ item { __typename } }")
+    assert result.data == {"item": {"__typename": "User"}}
 
 
 def test_union_type_resolver_may_be_set_using_decorator():
@@ -79,8 +80,8 @@ def test_union_type_resolver_may_be_set_using_decorator():
 
     schema = make_executable_schema(type_defs, [query, union])
 
-    result = graphql_sync(schema, test_query)
-    assert result.data == {"item": {"username": user.username}}
+    result = graphql_sync(schema, "{ item { __typename } }")
+    assert result.data == {"item": {"__typename": "User"}}
 
 
 def test_union_type_resolver_may_be_set_using_method():
@@ -91,8 +92,8 @@ def test_union_type_resolver_may_be_set_using_method():
     union.set_type_resolver(lambda *_: "User")
 
     schema = make_executable_schema(type_defs, [query, union])
-    result = graphql_sync(schema, test_query)
-    assert result.data == {"item": {"username": user.username}}
+    result = graphql_sync(schema, "{ item { __typename } }")
+    assert result.data == {"item": {"__typename": "User"}}
 
 
 def resolve_result_type(obj, *_):
@@ -110,7 +111,7 @@ def test_result_is_username_if_union_resolves_type_to_user():
 
     schema = make_executable_schema(type_defs, [query, union])
     result = graphql_sync(schema, test_query)
-    assert result.data == {"item": {"username": user.username}}
+    assert result.data == {"item": {"__typename": "User", "username": user.username}}
 
 
 def test_result_is_thread_title_if_union_resolves_type_to_thread():
@@ -120,7 +121,7 @@ def test_result_is_thread_title_if_union_resolves_type_to_thread():
 
     schema = make_executable_schema(type_defs, [query, union])
     result = graphql_sync(schema, test_query)
-    assert result.data == {"item": {"title": thread.title}}
+    assert result.data == {"item": {"__typename": "Thread", "title": thread.title}}
 
 
 def test_result_is_none_if_union_didnt_resolve_the_type():

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -59,7 +59,7 @@ thread = Mock(title="Thread")
 
 def test_union_type_resolver_may_be_set_on_initialization():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: user)
+    query.field("item", resolver=lambda *_: user)  # pylint: disable=unexpected-keyword-arg
 
     union = Union("FeedItem", type_resolver=lambda *_: "User")
     schema = make_executable_schema(type_defs, [query, union])
@@ -70,12 +70,12 @@ def test_union_type_resolver_may_be_set_on_initialization():
 
 def test_union_type_resolver_may_be_set_using_decorator():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: user)
+    query.field("item", resolver=lambda *_: user)  # pylint: disable=unexpected-keyword-arg
 
     union = Union("FeedItem")
 
     @union.type_resolver
-    def resolve_result_type(*_):
+    def resolve_result_type(*_):  # pylint: disable=unused-variable
         return "User"
 
     schema = make_executable_schema(type_defs, [query, union])
@@ -86,7 +86,7 @@ def test_union_type_resolver_may_be_set_using_decorator():
 
 def test_union_type_resolver_may_be_set_using_method():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: user)
+    query.field("item", resolver=lambda *_: user)  # pylint: disable=unexpected-keyword-arg
 
     union = Union("FeedItem")
     union.set_type_resolver(lambda *_: "User")
@@ -106,7 +106,7 @@ def resolve_result_type(obj, *_):
 
 def test_result_is_username_if_union_resolves_type_to_user():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: user)
+    query.field("item", resolver=lambda *_: user)  # pylint: disable=unexpected-keyword-arg
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])
@@ -116,7 +116,7 @@ def test_result_is_username_if_union_resolves_type_to_user():
 
 def test_result_is_thread_title_if_union_resolves_type_to_thread():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: thread)
+    query.field("item", resolver=lambda *_: thread)  # pylint: disable=unexpected-keyword-arg
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])
@@ -126,7 +126,7 @@ def test_result_is_thread_title_if_union_resolves_type_to_thread():
 
 def test_result_is_none_if_union_didnt_resolve_the_type():
     query = ResolverMap("Query")
-    query.field("item", resolver=lambda *_: True)
+    query.field("item", resolver=lambda *_: True)  # pylint: disable=unexpected-keyword-arg
     union = Union("FeedItem", type_resolver=resolve_result_type)
 
     schema = make_executable_schema(type_defs, [query, union])

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -88,20 +88,6 @@ def test_union_type_resolver_may_be_set_using_decorator():
     assert result.data == {"item": {"__typename": "User"}}
 
 
-def test_union_type_resolver_may_be_set_using_method():
-    query = ResolverMap("Query")
-    query.field(  # pylint: disable=unexpected-keyword-arg
-        "item", resolver=lambda *_: user
-    )
-
-    union = Union("FeedItem")
-    union.set_type_resolver(lambda *_: "User")
-
-    schema = make_executable_schema(type_defs, [query, union])
-    result = graphql_sync(schema, "{ item { __typename } }")
-    assert result.data == {"item": {"__typename": "User"}}
-
-
 def resolve_result_type(obj, *_):
     if obj == user:
         return "User"


### PR DESCRIPTION
This PR adds support for `union` types in GraphQL.

This is achieved by introduction of `ariadne.Union` bindable that takes name of union, and resolver function that takes any object and is expected to return `None` or `str` with GraphQL type name.

`Union` also implements new API as discussed in #98:

```
union = Union("Name", type_resolver)

# ...or...

@union.type_resolver
def resolver(*_):
    ...
```