### PR TITLE
Add interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Updated Playground to 1.8.7.
 - Split `GraphQLMiddleware` into two classes and moved it to `ariadne.wsgi`.
 - Made users responsible for calling `make_executable_schema`.
-- Added support for unions.
+- Added `Union` and `Interface` types.
+
 
 ## 0.2.0 (2019-01-07)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Documentation is available [here](https://ariadne.readthedocs.io/).
 - Asynchronous resolvers and query execution.
 - Subscriptions.
 - Custom scalars and enums.
-- Unions.
+- Unions and interfaces.
 - Defining schema using SDL strings.
 - Loading schema from `.graphql` files.
 - WSGI middleware for implementing GraphQL in existing sites.
@@ -31,8 +31,6 @@ Documentation is available [here](https://ariadne.readthedocs.io/).
 - Build-in simple synchronous dev server for quick GraphQL experimentation and GraphQL Playground.
 - Support for [Apollo GraphQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo).
 - GraphQL syntax validation via `gql()` helper function. Also provides colorization if Apollo GraphQL extension is installed.
-
-Following features should work but are not tested and documented: interfaces.
 
 
 ## Installation

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,5 +1,6 @@
 from .enums import Enum
 from .executable_schema import make_executable_schema
+from .interfaces import Interface
 from .load_schema import load_schema_from_path
 from .resolvers import (
     FallbackResolversSetter,
@@ -18,6 +19,7 @@ from .utils import convert_camel_case_to_snake, gql
 __all__ = [
     "Enum",
     "FallbackResolversSetter",
+    "Interface",
     "ResolverMap",
     "Scalar",
     "SnakeCaseFallbackResolversSetter",

--- a/ariadne/interfaces.py
+++ b/ariadne/interfaces.py
@@ -1,0 +1,34 @@
+from typing import Any, Callable, Dict, overload
+
+from graphql.type import GraphQLInterfaceType, GraphQLObjectType, GraphQLSchema
+
+from .resolvers import ResolverMap
+
+
+class Interface(ResolverMap):
+    def bind_to_schema(self, schema: GraphQLSchema) -> None:
+        graphql_type = schema.type_map.get(self.name)
+        self.validate_graphql_type(graphql_type)
+
+        for object_type in schema.type_map.values():
+            if type_implements_interface(self.name, object_type):
+                self.bind_resolvers_to_graphql_type(object_type, replace_existing=False)
+
+    def validate_graphql_type(self, graphql_type: str) -> None:
+        if not graphql_type:
+            raise ValueError("Interface %s is not defined in the schema" % self.name)
+        if not isinstance(graphql_type, GraphQLInterfaceType):
+            raise ValueError(
+                "%s is defined in the schema, but it is instance of %s (expected %s)"
+                % (
+                    self.name,
+                    type(graphql_type).__name__,
+                    GraphQLInterfaceType.__name__,
+                )
+            )
+
+
+def type_implements_interface(interface: str, graphql_type: GraphQLObjectType) -> bool:
+    if not isinstance(graphql_type, GraphQLObjectType):
+        return False
+    return interface in [i.name for i in graphql_type.interfaces]

--- a/ariadne/interfaces.py
+++ b/ariadne/interfaces.py
@@ -1,5 +1,3 @@
-from typing import Any, Callable, Dict, overload
-
 from graphql.type import GraphQLInterfaceType, GraphQLObjectType, GraphQLSchema
 
 from .resolvers import ResolverMap

--- a/ariadne/interfaces.py
+++ b/ariadne/interfaces.py
@@ -1,15 +1,31 @@
+from typing import Optional
+
 from graphql.type import GraphQLInterfaceType, GraphQLObjectType, GraphQLSchema
 
 from .resolvers import ResolverMap
+from .types import Resolver
 
 
 class Interface(ResolverMap):
+    _resolve_type: Optional[Resolver]
+
+    def __init__(self, name: str, type_resolver: Optional[Resolver] = None) -> None:
+        super().__init__(name)
+        self._resolve_type = type_resolver
+
+    def type_resolver(self, type_resolver: Resolver) -> Resolver:
+        self._resolve_type = type_resolver
+        return type_resolver
+
     def bind_to_schema(self, schema: GraphQLSchema) -> None:
         graphql_type = schema.type_map.get(self.name)
         self.validate_graphql_type(graphql_type)
 
+        graphql_type.resolve_type = self._resolve_type
+        self.bind_resolvers_to_graphql_type(graphql_type)
+
         for object_type in schema.type_map.values():
-            if type_implements_interface(self.name, object_type):
+            if _type_implements_interface(self.name, object_type):
                 self.bind_resolvers_to_graphql_type(object_type, replace_existing=False)
 
     def validate_graphql_type(self, graphql_type: str) -> None:
@@ -26,7 +42,7 @@ class Interface(ResolverMap):
             )
 
 
-def type_implements_interface(interface: str, graphql_type: GraphQLObjectType) -> bool:
+def _type_implements_interface(interface: str, graphql_type: GraphQLObjectType) -> bool:
     if not isinstance(graphql_type, GraphQLObjectType):
         return False
     return interface in [i.name for i in graphql_type.interfaces]

--- a/ariadne/resolvers.py
+++ b/ariadne/resolvers.py
@@ -75,6 +75,7 @@ class ResolverMap(Bindable):
         graphql_type = schema.type_map.get(self.name)
         self.validate_graphql_type(graphql_type)
         self.bind_resolvers_to_graphql_type(graphql_type)
+        self.bind_subscribers_to_graphql_type(graphql_type)
 
     def validate_graphql_type(self, graphql_type: str) -> None:
         if not graphql_type:
@@ -94,13 +95,14 @@ class ResolverMap(Bindable):
             if graphql_type.fields[field].resolve is None or replace_existing:
                 graphql_type.fields[field].resolve = resolver
 
+    def bind_subscribers_to_graphql_type(self, graphql_type):
         for field, subscriber in self._subscribers.items():
             if field not in graphql_type.fields:
                 raise ValueError(
                     "Field %s is not defined on type %s" % (field, self.name)
                 )
-            if graphql_type.fields[field].resolve is None or replace_existing:
-                graphql_type.fields[field].subscribe = subscriber
+
+            graphql_type.fields[field].subscribe = subscriber
 
 
 class FallbackResolversSetter(Bindable):

--- a/ariadne/resolvers.py
+++ b/ariadne/resolvers.py
@@ -74,20 +74,24 @@ class ResolverMap(Bindable):
     def bind_to_schema(self, schema: GraphQLSchema) -> None:
         graphql_type = schema.type_map.get(self.name)
         self.validate_graphql_type(graphql_type)
+        self.bind_resolvers_to_graphql_type(graphql_type)
 
+    def bind_resolvers_to_graphql_type(self, graphql_type, replace_existing=True):
         for field, resolver in self._resolvers.items():
             if field not in graphql_type.fields:
                 raise ValueError(
                     "Field %s is not defined on type %s" % (field, self.name)
                 )
-            graphql_type.fields[field].resolve = resolver
+            if graphql_type.fields[field].resolve is None or replace_existing:
+                graphql_type.fields[field].resolve = resolver
 
         for field, subscriber in self._subscribers.items():
             if field not in graphql_type.fields:
                 raise ValueError(
                     "Field %s is not defined on type %s" % (field, self.name)
                 )
-            graphql_type.fields[field].subscribe = subscriber
+            if graphql_type.fields[field].resolve is None or replace_existing:
+                graphql_type.fields[field].subscribe = subscriber
 
     def validate_graphql_type(self, graphql_type: str) -> None:
         if not graphql_type:

--- a/ariadne/resolvers.py
+++ b/ariadne/resolvers.py
@@ -76,6 +76,15 @@ class ResolverMap(Bindable):
         self.validate_graphql_type(graphql_type)
         self.bind_resolvers_to_graphql_type(graphql_type)
 
+    def validate_graphql_type(self, graphql_type: str) -> None:
+        if not graphql_type:
+            raise ValueError("Type %s is not defined in the schema" % self.name)
+        if not isinstance(graphql_type, GraphQLObjectType):
+            raise ValueError(
+                "%s is defined in the schema, but it is instance of %s (expected %s)"
+                % (self.name, type(graphql_type).__name__, GraphQLObjectType.__name__)
+            )
+
     def bind_resolvers_to_graphql_type(self, graphql_type, replace_existing=True):
         for field, resolver in self._resolvers.items():
             if field not in graphql_type.fields:
@@ -92,15 +101,6 @@ class ResolverMap(Bindable):
                 )
             if graphql_type.fields[field].resolve is None or replace_existing:
                 graphql_type.fields[field].subscribe = subscriber
-
-    def validate_graphql_type(self, graphql_type: str) -> None:
-        if not graphql_type:
-            raise ValueError("Type %s is not defined in the schema" % self.name)
-        if not isinstance(graphql_type, GraphQLObjectType):
-            raise ValueError(
-                "%s is defined in the schema, but it is instance of %s (expected %s)"
-                % (self.name, type(graphql_type).__name__, GraphQLObjectType.__name__)
-            )
 
 
 class FallbackResolversSetter(Bindable):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,7 @@ Table of contents
    scalars
    enums
    unions
+   interfaces
    subscriptions
    modularization
    local-development

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ Features
 - Asynchronous resolvers and query execution.
 - Subscriptions.
 - Custom scalars and enums.
-- Unions.
+- Unions and interfaces.
 - Defining schema using SDL strings.
 - Loading schema from ``.graphql`` files.
 - WSGI middleware for implementing GraphQL in existing sites.
@@ -23,8 +23,6 @@ Features
 - Build-in simple synchronous dev server for quick GraphQL experimentation and GraphQL Playground.
 - Support for `Apollo GraphQL extension for Visual Studio Code <https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo>`_.
 - GraphQL syntax validation via ``gql()`` helper function. Also provides colorization if Apollo GraphQL extension is installed.
-
-Following features should work but are not tested and documented: interfaces.
 
 
 Requirements and installation

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -40,7 +40,7 @@ Type definitions can then be updated to ``implement`` this interface::
     }
 
 
-GraphQL standard requires that every type implementing the ``Interface`` also explicitly defines the fields that this interface defines. This is why the ``summary`` and ``url`` fields repeat on all types in the example.
+GraphQL standard requires that every type implementing the ``Interface`` also explicitly defines fields from the interface. This is why the ``summary`` and ``url`` fields repeat on all types in the example.
 
 Like with the union, the ``SearchResult`` interface will also need a special resolver named *type resolver*. This resolver will we called with an object returned from a field resolver and current context, and should return a string containing the name of a GraphQL type, or ``None`` if the received type is incorrect::
 

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -54,8 +54,8 @@ Like with the union, the ``SearchResult`` interface will also need a special res
             return "Client"
         if isinstance(obj, Order):
             return "Order"
-        if isinstance(obj, String):
-            return "String"
+        if isinstance(obj, Product):
+            return "Product"
         return None
 
 .. note::
@@ -97,7 +97,7 @@ Ariadne's ``Interface`` instances can also optionally be used to share resolvers
     def resolve_url(obj, *_):
         return obj.get_absolute_url()
 
-Like in :ref:`ResolverMap <resolvers>`, ``field`` can be called as regular function::
+Like in the :ref:`ResolverMap <resolvers>`, ``field`` can be used as regular method::
 
     search_result.field("summary", resolver=resolve_summary)
     search_result.field("url", resolver=resolve_url)

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -1,9 +1,9 @@
 Interface types
 ===============
 
-Just like previously described :ref:`unions <unions>`, interfaces enable you to create fields that resolve to value that is one of few possible types.
+Just like previously described :ref:`unions <unions>`, interfaces enable you to create fields that resolve to a value that is one of a few possible types.
 
-Main feature that differs ``Interface`` from the ``Union`` is a contract defined by Schema's creator that GraphQL requires all possible types to implement.
+The main feature that differentiates ``Interface`` from the ``Union`` is a contract defined by Schema's creator that GraphQL requires all possible types to implement.
 
 .. note::
    It's recommended that you've read the :ref:`unions` section before continuing.
@@ -12,9 +12,9 @@ Main feature that differs ``Interface`` from the ``Union`` is a contract defined
 Interface example
 -----------------
 
-Consider an application implementing a search function. This search can return items of different type, like ``Client``, ``Order`` or ``Product``. For each result it displays short summary text that is a link leading to page containing item's details.
+Consider an application implementing a search function. This search can return items of different type, like ``Client``, ``Order`` or ``Product``. For each result it displays a short summary text that is a link leading to a page containing the item's details.
 
-An ``Interface`` can be created in schema that enforces that those types define ``summary`` and ``url`` fields::
+An ``Interface`` can be defined in schema that forces those types to define the ``summary`` and ``url`` fields::
 
     interface SearchResult {
         summary: String!
@@ -45,9 +45,9 @@ Type definitions can then be updated to ``implement`` this interface::
     }
 
 
-GraphQL standard requires that every type implementing the ``Interface`` also explicitly defines the fields that this interface defines. This is why ``summary`` and ``url`` fields repeat on all types in the example.
+GraphQL standard requires that every type implementing the ``Interface`` also explicitly defines the fields that this interface defines. This is why the ``summary`` and ``url`` fields repeat on all types in the example.
 
-Like with the union, the ``SearchResult`` interface will also need a special resolver named *type resolver*. This resolver will we called with an object returned from a field resolver and current context, and should return a string containing the name of an GraphQL type, or ``None`` if received type is incorrect::
+Like with the union, the ``SearchResult`` interface will also need a special resolver named *type resolver*. This resolver will we called with an object returned from a field resolver and current context, and should return a string containing the name of a GraphQL type, or ``None`` if the received type is incorrect::
 
     def resolve_search_result_type(obj, *_):
         if isinstance(obj, Client):
@@ -59,9 +59,9 @@ Like with the union, the ``SearchResult`` interface will also need a special res
         return None
 
 .. note::
-   Returning ``None`` from this resolver will result in ``null`` being returned for this field in your query's result. If field is not nullable, this will cause the GraphQL query to error.
+   Returning ``None`` from this resolver will result in ``null`` being returned for this field in your query's result. If a field is not nullable, this will cause the GraphQL query to error.
 
-Ariadne relies on dedicated ``Interface`` object for bindinding this function to Interface in your schema::
+Ariadne relies on a dedicated ``Interface`` object for binding this function to the ``Interface`` in your schema::
 
     from ariadne import Interface
 
@@ -71,14 +71,14 @@ Ariadne relies on dedicated ``Interface`` object for bindinding this function to
     def resolve_search_result_type(obj, *_):
         ...
 
-If this function is already defined elsewhere (e.g. 3rd party package), you can instantiate the ``Interface`` with it as second argument::
+If this function is already defined elsewhere (e.g. 3rd party package), you can instantiate the ``Interface`` with it as a second argument::
 
     from ariadne import Interface
     from .graphql import resolve_search_result_type
 
     search_result = Interface("SearchResult", resolve_search_result_type)
 
-Lastly, your ``Interface`` instance should be passed to ``make_executable_schema`` together will other resolvers::
+Lastly, your ``Interface`` instance should be passed to ``make_executable_schema`` together with other resolvers::
 
     schema = make_executable_schema(type_defs, [query, search_result])
 
@@ -97,9 +97,9 @@ Ariadne's ``Interface`` instances can also optionally be used to share resolvers
     def resolve_url(obj, *_):
         return obj.get_absolute_url()
 
-Like in the :ref:`ResolverMap <resolvers>`, ``field`` can be used as regular method::
+Like in the :ref:`ResolverMap <resolvers>`, ``field`` can be used as a regular method::
 
     search_result.field("summary", resolver=resolve_summary)
     search_result.field("url", resolver=resolve_url)
 
-Unlike the ``ResolverMap``, ``Interface`` assigns the resolver to field only if that field has no resolver already set.
+Unlike the ``ResolverMap``, ``Interface`` assigns the resolver to a field only if that field has no resolver already set.

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -1,18 +1,13 @@
 Interface types
 ===============
 
-Just like previously described :ref:`unions <unions>`, interfaces enable you to create fields that resolve to a value that is one of a few possible types.
-
-The main feature that differentiates ``Interface`` from the ``Union`` is a contract defined by Schema's creator that GraphQL requires all possible types to implement.
-
-.. note::
-   It's recommended that you've read the :ref:`unions` section before continuing.
+Interface is an abstract GraphQL type that defines certain set of fields and requires other types *implementing* it to also define same fields in order for schema to be correct.
 
 
 Interface example
 -----------------
 
-Consider an application implementing a search function. This search can return items of different type, like ``Client``, ``Order`` or ``Product``. For each result it displays a short summary text that is a link leading to a page containing the item's details.
+Consider an application implementing a search function. Search can return items of different type, like ``Client``, ``Order`` or ``Product``. For each result it displays a short summary text that is a link leading to a page containing the item's details.
 
 An ``Interface`` can be defined in schema that forces those types to define the ``summary`` and ``url`` fields::
 
@@ -83,10 +78,12 @@ Lastly, your ``Interface`` instance should be passed to ``make_executable_schema
     schema = make_executable_schema(type_defs, [query, search_result])
 
 
-Sharing resolvers between types
--------------------------------
+Field resolvers
+---------------
 
-Ariadne's ``Interface`` instances can also optionally be used to share resolvers between implementing types::
+Ariadne's ``Interface`` instances can optionally be used to set resolvers on implementing types fields.
+
+``SearchResult`` interface from previous section implements two fields: ``summary`` and ``url``. If resolver implementation for those fields is same for multiple types implementing the interface, ``Interface`` instance can be used set those resolvers for those fields::
 
     @search_result.field("summary")
     def resolve_summary(obj, *_):
@@ -102,4 +99,5 @@ Like in the :ref:`ResolverMap <resolvers>`, ``field`` can be used as a regular m
     search_result.field("summary", resolver=resolve_summary)
     search_result.field("url", resolver=resolve_url)
 
-Unlike the ``ResolverMap``, ``Interface`` assigns the resolver to a field only if that field has no resolver already set.
+.. note::
+   ``Interface`` assigns the resolver to a field only if that field has no resolver already set. This is different from ``ResolverMap`` that sets resolvers fields if field already has other resolver set.

--- a/docs/interfaces.rst
+++ b/docs/interfaces.rst
@@ -1,0 +1,105 @@
+Interface types
+===============
+
+Just like previously described :ref:`unions <unions>`, interfaces enable you to create fields that resolve to value that is one of few possible types.
+
+Main feature that differs ``Interface`` from the ``Union`` is a contract defined by Schema's creator that GraphQL requires all possible types to implement.
+
+.. note::
+   It's recommended that you've read the :ref:`unions` section before continuing.
+
+
+Interface example
+-----------------
+
+Consider an application implementing a search function. This search can return items of different type, like ``Client``, ``Order`` or ``Product``. For each result it displays short summary text that is a link leading to page containing item's details.
+
+An ``Interface`` can be created in schema that enforces that those types define ``summary`` and ``url`` fields::
+
+    interface SearchResult {
+        summary: String!
+        url: String!
+    }
+
+Type definitions can then be updated to ``implement`` this interface::
+
+    type Client implements SearchResult {
+        first_name: String!
+        last_name: String!
+        summary: String!
+        url: String!
+    }
+
+    type Order implements SearchResult {
+        ref: String!
+        client: Client!
+        summary: String!
+        url: String!
+    }
+
+    type Product implements SearchResult {
+        name: String!
+        sku: String!
+        summary: String!
+        url: String!
+    }
+
+
+GraphQL standard requires that every type implementing the ``Interface`` also explicitly defines the fields that this interface defines. This is why ``summary`` and ``url`` fields repeat on all types in the example.
+
+Like with the union, the ``SearchResult`` interface will also need a special resolver named *type resolver*. This resolver will we called with an object returned from a field resolver and current context, and should return a string containing the name of an GraphQL type, or ``None`` if received type is incorrect::
+
+    def resolve_search_result_type(obj, *_):
+        if isinstance(obj, Client):
+            return "Client"
+        if isinstance(obj, Order):
+            return "Order"
+        if isinstance(obj, String):
+            return "String"
+        return None
+
+.. note::
+   Returning ``None`` from this resolver will result in ``null`` being returned for this field in your query's result. If field is not nullable, this will cause the GraphQL query to error.
+
+Ariadne relies on dedicated ``Interface`` object for bindinding this function to Interface in your schema::
+
+    from ariadne import Interface
+
+    search_result = Interface("SearchResult")
+
+    @search_result.type_resolver
+    def resolve_search_result_type(obj, *_):
+        ...
+
+If this function is already defined elsewhere (e.g. 3rd party package), you can instantiate the ``Interface`` with it as second argument::
+
+    from ariadne import Interface
+    from .graphql import resolve_search_result_type
+
+    search_result = Interface("SearchResult", resolve_search_result_type)
+
+Lastly, your ``Interface`` instance should be passed to ``make_executable_schema`` together will other resolvers::
+
+    schema = make_executable_schema(type_defs, [query, search_result])
+
+
+Sharing resolvers between types
+-------------------------------
+
+Ariadne's ``Interface`` instances can also optionally be used to share resolvers between implementing types::
+
+    @search_result.field("summary")
+    def resolve_summary(obj, *_):
+        return str(obj)
+
+    
+    @search_result.field("url")
+    def resolve_url(obj, *_):
+        return obj.get_absolute_url()
+
+Like in :ref:`ResolverMap <resolvers>`, ``field`` can be called as regular function::
+
+    search_result.field("summary", resolver=resolve_summary)
+    search_result.field("url", resolver=resolve_url)
+
+Unlike the ``ResolverMap``, ``Interface`` assigns the resolver to field only if that field has no resolver already set.

--- a/docs/unions.rst
+++ b/docs/unions.rst
@@ -1,3 +1,5 @@
+.. _unions:
+
 Union types
 ===========
 
@@ -46,7 +48,7 @@ Your union will also need a special resolver named *type resolver*. This resolve
         return None
 
 .. note::
-   Returning ``None`` from this resolver will result in ``null`` being returned for this field in your query's result.
+   Returning ``None`` from this resolver will result in ``null`` being returned for this field in your query's result. If field is not nullable, this will cause the GraphQL query to error.
 
 Ariadne relies on dedicated ``Union`` object for bindinding this function to Union in your schema::
 

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -238,7 +238,7 @@ def test_interface_resolver_doesnt_override_existing_resolver(schema, interface)
     user.bind_to_schema(schema)
 
     def interface_resolver(*_):
-        pass
+        pass  # pragma: no cover
 
     interface.field("summary", resolver=interface_resolver)
     interface.bind_to_schema(schema)

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,48 +1,247 @@
 from unittest.mock import Mock
 
-from graphql import graphql_sync, build_schema
+import pytest
+from graphql import build_schema, graphql_sync
 
-from ariadne import Interface, ResolverMap
-
+from ariadne import Interface, ResolverMap, make_executable_schema
 
 type_defs = """
     type Query {
-        cat: Cat!
-        dog: Dog!
+        result: SearchResult!
+        user: User!
+        thread: Thread!
     }
 
-    type Cat implements Sound {
-        sound: String!
+    type User implements SearchResult {
+        username: String!
+        summary: String!
     }
 
-    type Dog implements Sound {
-        sound: String!
+    type Thread implements SearchResult {
+        title: String!
+        summary: String!
     }
 
-    interface Sound {
-        sound: String!
+    type Post {
+        summary: String!
+    }
+
+    interface SearchResult {
+        summary: String!
     }
 """
 
-Cat = Mock(make_sound=Mock(return_value="Meow"))
-Dog = Mock(make_sound=Mock(return_value="Bark"))
+
+@pytest.fixture
+def schema():
+    return build_schema(type_defs)
 
 
-def test_interface_binds_its_resolvers_to_implementing_types_fields():
-    schema = build_schema(type_defs)
+def test_attempt_bind_interface_to_undefined_type_raises_error(schema):
+    interface = Interface("Test")
+    with pytest.raises(ValueError):
+        interface.bind_to_schema(schema)
 
-    query = ResolverMap("Query")
-    query.field("cat", resolver=lambda *_: Cat)
-    query.field("dog", resolver=lambda *_: Dog)
-    query.bind_to_schema(schema)
 
-    def interface_resolver(obj, *_):
-        return obj.make_sound()
+def test_attempt_bind_interface_to_invalid_type_raises_error(schema):
+    interface = Interface("Query")
+    with pytest.raises(ValueError):
+        interface.bind_to_schema(schema)
 
-    sound = Interface("Sound")
-    sound.field("sound", resolver=interface_resolver)
-    sound.bind_to_schema(schema)
 
-    result = graphql_sync(schema, "{ cat { sound } dog { sound } }")
+test_query = """
+    {
+        result {
+            __typename
+            ... on User {
+                username
+                summary
+            }
+            ... on Thread {
+                title
+                summary
+            }
+        }
+    }
+"""
 
-    assert result.data == {"cat": {"sound": "Meow"}, "dog": {"sound": "Bark"}}
+User = Mock(username="User", summary="User Summary")
+Thread = Mock(title="Thread", summary="Thread Summary")
+
+
+@pytest.fixture
+def query():
+    return ResolverMap("Query")
+
+
+@pytest.fixture
+def query_with_user_result(query):
+    query.field(  # pylint: disable=unexpected-keyword-arg
+        "result", resolver=lambda *_: User
+    )
+    return query
+
+
+@pytest.fixture
+def query_with_thread_result(query):
+    query.field(  # pylint: disable=unexpected-keyword-arg
+        "result", resolver=lambda *_: Thread
+    )
+    return query
+
+
+@pytest.fixture
+def query_with_invalid_result(query):
+    query.field(  # pylint: disable=unexpected-keyword-arg
+        "result", resolver=lambda *_: True
+    )
+    return query
+
+
+def test_interface_type_resolver_may_be_set_on_initialization(query_with_user_result):
+    interface = Interface("SearchResult", type_resolver=lambda *_: "User")
+    schema = make_executable_schema(type_defs, [query_with_user_result, interface])
+    result = graphql_sync(schema, "{ result { __typename } }")
+    assert result.data == {"result": {"__typename": "User"}}
+
+
+def test_interface_type_resolver_may_be_set_using_decorator(query_with_user_result):
+    interface = Interface("SearchResult")
+
+    @interface.type_resolver
+    def resolve_result_type(*_):  # pylint: disable=unused-variable
+        return "User"
+
+    schema = make_executable_schema(type_defs, [query_with_user_result, interface])
+    result = graphql_sync(schema, "{ result { __typename } }")
+    assert result.data == {"result": {"__typename": "User"}}
+
+
+def resolve_result_type(obj, *_):
+    if obj == User:
+        return "User"
+    if obj == Thread:
+        return "Thread"
+    return None
+
+
+@pytest.fixture
+def interface():
+    return Interface("SearchResult", type_resolver=resolve_result_type)
+
+
+def test_result_is_username_if_interface_resolves_type_to_user(
+    query_with_user_result, interface
+):
+    schema = make_executable_schema(type_defs, [query_with_user_result, interface])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {
+        "result": {
+            "__typename": "User",
+            "username": User.username,
+            "summary": User.summary,
+        }
+    }
+
+
+def test_result_is_thread_title_if_interface_resolves_type_to_thread(
+    query_with_thread_result, interface
+):
+    schema = make_executable_schema(type_defs, [query_with_thread_result, interface])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {
+        "result": {
+            "__typename": "Thread",
+            "title": Thread.title,
+            "summary": Thread.summary,
+        }
+    }
+
+
+def test_query_errors_if_interface_didnt_resolve_the_type(
+    query_with_invalid_result, interface
+):
+    schema = make_executable_schema(type_defs, [query_with_invalid_result, interface])
+    result = graphql_sync(schema, test_query)
+    assert result.errors
+    assert not result.data
+
+
+def test_attempt_bind_interface_field_to_undefined_field_raises_error(
+    schema, interface
+):
+    interface.alias("score", "_")
+    with pytest.raises(ValueError):
+        interface.bind_to_schema(schema)
+
+
+def test_resolver(*_):
+    pass
+
+
+def test_field_method_assigns_decorated_function_as_field_resolver(
+    schema, query_with_user_result, interface
+):
+    interface.field("summary")(test_resolver)
+    interface.bind_to_schema(schema)
+    query_with_user_result.bind_to_schema(schema)
+
+    field = schema.type_map.get(interface.name).fields["summary"]
+    assert field.resolve is test_resolver
+
+
+def test_field_method_assigns_function_as_field_resolver(
+    schema, query_with_user_result, interface
+):
+    interface.field("summary", resolver=test_resolver)
+    interface.bind_to_schema(schema)
+    query_with_user_result.bind_to_schema(schema)
+
+    field = schema.type_map.get(interface.name).fields["summary"]
+    assert field.resolve is test_resolver
+
+
+def test_alias_method_creates_resolver_for_specified_attribute(
+    schema, query_with_user_result, interface
+):
+    interface.alias("summary", "username")
+    interface.bind_to_schema(schema)
+    query_with_user_result.bind_to_schema(schema)
+
+    field = schema.type_map.get(interface.name).fields["summary"]
+    assert field.resolve
+
+
+def test_interface_doesnt_set_resolver_for_type_not_implementing_it(schema, interface):
+    interface.field("summary")(lambda *_: "Summary")
+    interface.bind_to_schema(schema)
+
+    field = schema.type_map.get("Post").fields["summary"]
+    assert field.resolve is None
+
+
+def test_interface_sets_resolver_on_implementing_types(schema, interface):
+    interface.field("summary", resolver=test_resolver)
+    interface.bind_to_schema(schema)
+
+    user_field = schema.type_map.get("User").fields["summary"]
+    assert user_field.resolve is test_resolver
+    thread_field = schema.type_map.get("Thread").fields["summary"]
+    assert thread_field.resolve is test_resolver
+
+
+def test_interface_resolver_doesnt_override_existing_resolver(schema, interface):
+    user = ResolverMap("User")
+    user.field(  # pylint: disable=unexpected-keyword-arg
+        "summary", resolver=test_resolver
+    )
+    user.bind_to_schema(schema)
+
+    def interface_resolver(*_):
+        pass
+
+    interface.field("summary", resolver=interface_resolver)
+    interface.bind_to_schema(schema)
+
+    field = schema.type_map.get("User").fields["summary"]
+    assert field.resolve is test_resolver

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -1,0 +1,48 @@
+from unittest.mock import Mock
+
+from graphql import graphql_sync, build_schema
+
+from ariadne import Interface, ResolverMap
+
+
+type_defs = """
+    type Query {
+        cat: Cat!
+        dog: Dog!
+    }
+
+    type Cat implements Sound {
+        sound: String!
+    }
+
+    type Dog implements Sound {
+        sound: String!
+    }
+
+    interface Sound {
+        sound: String!
+    }
+"""
+
+Cat = Mock(make_sound=Mock(return_value="Meow"))
+Dog = Mock(make_sound=Mock(return_value="Bark"))
+
+
+def test_interface_binds_its_resolvers_to_implementing_types_fields():
+    schema = build_schema(type_defs)
+
+    query = ResolverMap("Query")
+    query.field("cat", resolver=lambda *_: Cat)
+    query.field("dog", resolver=lambda *_: Dog)
+    query.bind_to_schema(schema)
+
+    def interface_resolver(obj, *_):
+        return obj.make_sound()
+
+    sound = Interface("Sound")
+    sound.field("sound", resolver=interface_resolver)
+    sound.bind_to_schema(schema)
+
+    result = graphql_sync(schema, "{ cat { sound } dog { sound } }")
+
+    assert result.data == {"cat": {"sound": "Meow"}, "dog": {"sound": "Bark"}}

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -7,7 +7,7 @@ from ariadne import Interface, ResolverMap, make_executable_schema
 
 type_defs = """
     type Query {
-        result: SearchResult!
+        result: SearchResult
         user: User!
         thread: Thread!
     }
@@ -163,8 +163,7 @@ def test_query_errors_if_interface_didnt_resolve_the_type(
 ):
     schema = make_executable_schema(type_defs, [query_with_invalid_result, interface])
     result = graphql_sync(schema, test_query)
-    assert result.errors
-    assert not result.data
+    assert result.data == {"result": None}
 
 
 def test_attempt_bind_interface_field_to_undefined_field_raises_error(

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -37,13 +37,13 @@ def schema():
     return build_schema(type_defs)
 
 
-def test_attempt_bind_interface_to_undefined_type_raises_error(schema):
+def test_attempt_to_bind_interface_to_undefined_type_raises_error(schema):
     interface = Interface("Test")
     with pytest.raises(ValueError):
         interface.bind_to_schema(schema)
 
 
-def test_attempt_bind_interface_to_invalid_type_raises_error(schema):
+def test_attempt_to_bind_interface_to_invalid_type_raises_error(schema):
     interface = Interface("Query")
     with pytest.raises(ValueError):
         interface.bind_to_schema(schema)

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -27,13 +27,13 @@ def schema():
     return build_schema(type_defs)
 
 
-def test_attempt_bind_union_to_undefined_type_raises_error(schema):
+def test_attempt_to_bind_union_to_undefined_type_raises_error(schema):
     union = Union("Test")
     with pytest.raises(ValueError):
         union.bind_to_schema(schema)
 
 
-def test_attempt_bind_union_to_invalid_type_raises_error(schema):
+def test_attempt_to_bind_union_to_invalid_type_raises_error(schema):
     union = Union("Query")
     with pytest.raises(ValueError):
         union.bind_to_schema(schema)


### PR DESCRIPTION
This PR adds `Interface` type to Ariadne. Interface acts like the union, except it enforces intersection between implementing types. It also allows (optional) resolvers reuse between implementing types.

~~Currently, this is a proof-of-concept implementation.~~

### TODO

* [x] Use interface to reuse resolvers
* [x] Use interface as return type (needs `type_resolver` like union does)
* [x] Tests
* [x] Docs
* [x] Changelog