### PR TITLE
Setup black to ignore tests snapshots

### DIFF
--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -16,7 +16,7 @@ class ScalarType(SchemaBindable):
         *,
         serializer: ScalarOperation = None,
         value_parser: ScalarOperation = None,
-        literal_parser: ScalarOperation = None
+        literal_parser: ScalarOperation = None,
     ) -> None:
         self.name = name
         self._serialize = serializer

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -158,7 +158,7 @@ class GraphQLMiddleware:
         schema: GraphQLSchema,
         path: str = "/graphql/",
         *,
-        server_class: type = GraphQL
+        server_class: type = GraphQL,
     ) -> None:
         self.app = app
         self.path = path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 88
+target-version = ['py36', 'py37', 'py38']
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.eggs
+  | \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+  | snapshots
+)/
+'''


### PR DESCRIPTION
This PR adds `pyproject.toml` file that excludes bunch of directories from black, including `snapshots` dir created by pytest snapshot plugin.