### PR TITLE
Handle exceptions occuring during context repr() creation

### DIFF
--- a/ariadne/format_errors.py
+++ b/ariadne/format_errors.py
@@ -1,6 +1,6 @@
 from traceback import format_exception
 
-from typing import List, Optional
+from typing import Any, List, Optional
 
 from graphql import ExecutionResult, GraphQLError
 
@@ -54,4 +54,11 @@ def get_formatted_context(error: Exception) -> Optional[dict]:
         tb_last = tb_last.tb_next
     if tb_last is None:
         return None
-    return {key: repr(value) for key, value in tb_last.tb_frame.f_locals.items()}
+    return {key: safe_repr(value) for key, value in tb_last.tb_frame.f_locals.items()}
+
+
+def safe_repr(value: Any) -> Any:
+    try:
+        return repr(value)
+    except Exception as e:
+        return "repr() has raised %s exception: %s" % (type(e).__name__, e)

--- a/ariadne/format_errors.py
+++ b/ariadne/format_errors.py
@@ -1,3 +1,4 @@
+from reprlib import repr
 from traceback import format_exception
 
 from typing import Any, List, Optional
@@ -54,11 +55,4 @@ def get_formatted_context(error: Exception) -> Optional[dict]:
         tb_last = tb_last.tb_next
     if tb_last is None:
         return None
-    return {key: safe_repr(value) for key, value in tb_last.tb_frame.f_locals.items()}
-
-
-def safe_repr(value: Any) -> Any:
-    try:
-        return repr(value)
-    except Exception as e:  # pylint: disable=broad-except
-        return "repr() has raised %s exception: %s" % (type(e).__name__, e)
+    return {key: repr(value) for key, value in tb_last.tb_frame.f_locals.items()}

--- a/ariadne/format_errors.py
+++ b/ariadne/format_errors.py
@@ -1,7 +1,7 @@
-from reprlib import repr
+from reprlib import repr  # pylint: disable=redefined-builtin
 from traceback import format_exception
 
-from typing import Any, List, Optional
+from typing import List, Optional
 
 from graphql import ExecutionResult, GraphQLError
 

--- a/ariadne/format_errors.py
+++ b/ariadne/format_errors.py
@@ -60,5 +60,5 @@ def get_formatted_context(error: Exception) -> Optional[dict]:
 def safe_repr(value: Any) -> Any:
     try:
         return repr(value)
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
         return "repr() has raised %s exception: %s" % (type(e).__name__, e)

--- a/tests/test_error_formatting.py
+++ b/tests/test_error_formatting.py
@@ -9,11 +9,17 @@ from ariadne.format_errors import (
     format_error,
     get_error_extension,
     get_formatted_context,
+    safe_repr,
 )
 
 
 @pytest.fixture
-def erroring_resolvers():
+def failing_repr_mock():
+    return Mock(__repr__=Mock(side_effect=KeyError("test")), spec=["__repr__"])
+
+
+@pytest.fixture
+def erroring_resolvers(failing_repr_mock):
     query = QueryType()
 
     @query.field("hello")
@@ -23,6 +29,7 @@ def erroring_resolvers():
         test_str = "test"
         test_dict = {"test": "dict"}
         test_obj = query
+        test_failing_repr = failing_repr_mock
         test_undefined.error()  # trigger attr not found error
 
     return query
@@ -58,17 +65,18 @@ def test_default_formatter_extends_error_with_context(schema):
     assert error["extensions"]["exception"]["context"]
 
 
-def test_default_formatter_fills_context_with_reprs_of_python_context(
-    schema, erroring_resolvers
+def test_default_formatter_fills_context_with_safe_reprs_of_python_context(
+    schema, erroring_resolvers, failing_repr_mock
 ):
     result = graphql_sync(schema, "{ hello }")
     error = format_errors(result, format_error, debug=True)[0]
     context = error["extensions"]["exception"]["context"]
 
-    assert context["test_int"] == repr(123)
-    assert context["test_str"] == repr("test")
-    assert context["test_dict"] == repr({"test": "dict"})
-    assert context["test_obj"] == repr(erroring_resolvers)
+    assert context["test_int"] == safe_repr(123)
+    assert context["test_str"] == safe_repr("test")
+    assert context["test_dict"] == safe_repr({"test": "dict"})
+    assert context["test_failing_repr"] == safe_repr(failing_repr_mock)
+    assert context["test_obj"] == safe_repr(erroring_resolvers)
 
 
 def test_default_formatter_is_not_extending_plain_graphql_error(schema):
@@ -85,3 +93,11 @@ def test_error_extension_is_not_available_for_error_without_traceback():
 def test_incomplete_traceback_is_handled_by_context_extractor():
     error = Mock(__traceback__=None, spec=["__traceback__"])
     assert get_formatted_context(error) is None
+
+
+def test_safe_repr_handles_exception_during_repr(failing_repr_mock):
+    assert safe_repr(failing_repr_mock)
+
+
+def test_safe_repr_includes_exception_type_in_repr(failing_repr_mock):
+    assert "KeyError" in safe_repr(failing_repr_mock)

--- a/tests/test_error_formatting.py
+++ b/tests/test_error_formatting.py
@@ -1,4 +1,4 @@
-from reprlib import repr
+from reprlib import repr  # pylint: disable=redefined-builtin
 from unittest.mock import Mock
 
 import pytest

--- a/tests/test_error_formatting.py
+++ b/tests/test_error_formatting.py
@@ -1,3 +1,4 @@
+from reprlib import repr
 from unittest.mock import Mock
 
 import pytest
@@ -9,7 +10,6 @@ from ariadne.format_errors import (
     format_error,
     get_error_extension,
     get_formatted_context,
-    safe_repr,
 )
 
 
@@ -65,18 +65,18 @@ def test_default_formatter_extends_error_with_context(schema):
     assert error["extensions"]["exception"]["context"]
 
 
-def test_default_formatter_fills_context_with_safe_reprs_of_python_context(
+def test_default_formatter_fills_context_with_reprs_of_python_context(
     schema, erroring_resolvers, failing_repr_mock
 ):
     result = graphql_sync(schema, "{ hello }")
     error = format_errors(result, format_error, debug=True)[0]
     context = error["extensions"]["exception"]["context"]
 
-    assert context["test_int"] == safe_repr(123)
-    assert context["test_str"] == safe_repr("test")
-    assert context["test_dict"] == safe_repr({"test": "dict"})
-    assert context["test_failing_repr"] == safe_repr(failing_repr_mock)
-    assert context["test_obj"] == safe_repr(erroring_resolvers)
+    assert context["test_int"] == repr(123)
+    assert context["test_str"] == repr("test")
+    assert context["test_dict"] == repr({"test": "dict"})
+    assert context["test_failing_repr"] == repr(failing_repr_mock)
+    assert context["test_obj"] == repr(erroring_resolvers)
 
 
 def test_default_formatter_is_not_extending_plain_graphql_error(schema):
@@ -93,11 +93,3 @@ def test_error_extension_is_not_available_for_error_without_traceback():
 def test_incomplete_traceback_is_handled_by_context_extractor():
     error = Mock(__traceback__=None, spec=["__traceback__"])
     assert get_formatted_context(error) is None
-
-
-def test_safe_repr_handles_exception_during_repr(failing_repr_mock):
-    assert safe_repr(failing_repr_mock)
-
-
-def test_safe_repr_includes_exception_type_in_repr(failing_repr_mock):
-    assert "KeyError" in safe_repr(failing_repr_mock)


### PR DESCRIPTION
This PR replaces default `repr` with `reprlib.repr` util that handles exceptions coming from the `__repr__` and is also a function used by Python debugger.