### PR TITLE
Add extension support to make_executable_schema issue #95

### DIFF
--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -26,6 +26,17 @@ def extract_extensions(ast: DocumentNode) -> DocumentNode:
     return DocumentNode(definitions=extensions)
 
 
+def build_and_extend_schema(ast: DocumentNode) -> GraphQLSchema:
+    schema = build_ast_schema(ast)
+
+    extension_ast = extract_extensions(ast)
+
+    if extension_ast.definitions:
+        schema = extend_schema(schema, extension_ast)
+
+    return schema
+
+
 def make_executable_schema(
     type_defs: Union[str, List[str]],
     bindables: Union[SchemaBindable, List[SchemaBindable], None] = None,
@@ -35,12 +46,7 @@ def make_executable_schema(
 
     ast_document = parse(type_defs)
 
-    schema = build_ast_schema(ast_document)
-
-    extension_ast = extract_extensions(ast_document)
-
-    if len(extension_ast.definitions) > 0:
-        schema = extend_schema(schema, extension_ast)
+    schema = build_and_extend_schema(ast_document)
 
     if isinstance(bindables, list):
         for obj in bindables:

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -5,18 +5,18 @@ from graphql import GraphQLSchema, DocumentNode, parse, build_ast_schema, extend
 from .types import SchemaBindable
 
 
-newExtensionDefinitionKind = 'object_type_extension'
-interfaceExtensionDefinitionKind = 'interface_type_extension'
-inputObjectExtensionDefinitionKind = 'input_object_type_extension'
-unionExtensionDefinitionKind = 'union_type_extension'
-enumExtensionDefinitionKind = 'enum_type_extension'
+new_extension_definition_kind = "object_type_extension"
+interface_extension_definition_kind = "interface_type_extension"
+input_object_extension_definition_kind = "input_object_type_extension"
+union_extension_definition_kind = "union_type_extension"
+enum_extension_definition_kind = "enum_type_extension"
 
 extension_kinds = [
-    newExtensionDefinitionKind,
-    interfaceExtensionDefinitionKind,
-    inputObjectExtensionDefinitionKind,
-    unionExtensionDefinitionKind,
-    enumExtensionDefinitionKind,
+    new_extension_definition_kind,
+    interface_extension_definition_kind,
+    input_object_extension_definition_kind,
+    union_extension_definition_kind,
+    enum_extension_definition_kind,
 ]
 
 
@@ -39,7 +39,7 @@ def make_executable_schema(
 
     extension_ast = extract_extensions(ast_document)
 
-    if len(extension_ast.definitions):
+    if len(extension_ast.definitions) > 0:
         schema = extend_schema(schema, extension_ast)
 
     if isinstance(bindables, list):


### PR DESCRIPTION
This addresses issue #95 

I have ported the logic from graphql-tools [buildSchemaFromTypeDefs](https://github.com/apollographql/graphql-tools/blob/master/src/generate/buildSchemaFromTypeDefinitions.ts#L48), which parse an ast document node then checks if there is any extension type included in the type defs. Those are pulled out and added to a new document that then uses the 'extend_schema' to extend the existing schema. 

Not exactly sure how you want to organize this but this is a working first pass.

Thanks!