### PR TITLE
Removed duplicate import in Django example

### DIFF
--- a/docs/custom-server.rst
+++ b/docs/custom-server.rst
@@ -48,7 +48,6 @@ The following example presents a basic GraphQL server using a Django framework::
         HttpResponseBadRequest, JsonResponse
     )
     from django.views.decorators.csrf import csrf_exempt
-    from graphql import graphql_sync
 
     type_defs = """
         type Query {


### PR DESCRIPTION
The Django example imported `graphql_sync` from ariadne but also from graphql. The import from graphql should be removed and is a artifact of the old example when ariadne offered no graphql_sync function (before version 0.3.0).