### PR TITLE
Improve integration docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -42,7 +42,7 @@ release = "0.3"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = []
+extensions = ["sphinxcontrib.asyncio"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -6,6 +6,7 @@ pytest-asyncio
 pytest-mock
 snapshottest
 requests
+sphinxcontrib-asyncio
 starlette
 
 pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,31 +4,50 @@
 #
 #    pip-compile requirements-dev.in -o requirements-dev.txt
 #
+alabaster==0.7.12         # via sphinx
 appdirs==1.4.3            # via black
 astroid==2.0.4            # via pylint
 atomicwrites==1.2.1       # via pytest
 attrs==18.2.0             # via black, pytest
+babel==2.6.0              # via sphinx
 black==19.3b0
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
 click==7.0                # via black, pip-tools
+docutils==0.14            # via sphinx
 idna==2.8                 # via requests
+imagesize==1.1.0          # via sphinx
 isort==4.3.4              # via pylint
+jinja2==2.10.1            # via sphinx
 lazy-object-proxy==1.3.1  # via astroid
+markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 more-itertools==4.3.0     # via pytest
 mypy-extensions==0.4.1    # via mypy
 mypy==0.641
+packaging==19.0           # via sphinx
 pip-tools==3.5.0
 pluggy==0.8.0             # via pytest
 py==1.7.0                 # via pytest
+pygments==2.3.1           # via sphinx
 pylint==2.1.1
+pyparsing==2.4.0          # via packaging
 pytest-asyncio==0.10.0
 pytest-mock==1.10.0
 pytest==3.9.3
+pytz==2019.1              # via babel
 requests==2.21.0
-six==1.11.0               # via astroid, more-itertools, pip-tools, pytest, snapshottest
+six==1.11.0               # via astroid, more-itertools, packaging, pip-tools, pytest, snapshottest
 snapshottest==0.5.0
+snowballstemmer==1.2.1    # via sphinx
+sphinx==2.0.1             # via sphinxcontrib-asyncio
+sphinxcontrib-applehelp==1.0.1  # via sphinx
+sphinxcontrib-asyncio==0.2.0
+sphinxcontrib-devhelp==1.0.1  # via sphinx
+sphinxcontrib-htmlhelp==1.0.2  # via sphinx
+sphinxcontrib-jsmath==1.0.1  # via sphinx
+sphinxcontrib-qthelp==1.0.2  # via sphinx
+sphinxcontrib-serializinghtml==1.1.3  # via sphinx
 starlette==0.11.4
 termcolor==1.1.0          # via snapshottest
 toml==0.10.0              # via black


### PR DESCRIPTION
I've removed the now-duplicate description of `make_executable_schema` and instead have included the convenience functions needed for clean integration.