### PR TITLE
Update documentation of context_for_request method to match definition

### DIFF
--- a/docs/asgi.rst
+++ b/docs/asgi.rst
@@ -39,9 +39,10 @@ Customizing context or root
     :param variables: an optional `dict` representing the query variables.
     :return: value that should be passed to root resolvers as the parent (first argument).
 
-.. method:: GraphQL.context_for_request(request)
+.. method:: GraphQL.context_for_request(request, data)
 
     :param request: either a `Request` sent by the client or a message sent over a `WebSocket`.
+    :param data: the request's JSON content, if defined
     :return: value that should be passed to resolvers as ``context`` attribute on the ``info`` argument.
 
 The following example shows custom a GraphQL server that defines its own root and context::
@@ -54,5 +55,5 @@ The following example shows custom a GraphQL server that defines its own root an
         def root_value_for_document(self, query, variables):
             return DataLoader()
 
-        def context_for_request(self, request):
+        def context_for_request(self, request, data):
             return MyContext(request)


### PR DESCRIPTION
It looks like this method definition in the docs is slightly out of sync with the implementation. 🙂 

```
  File "lib/python3.7/site-packages/ariadne/asgi.py", line 100, in graphql_http_server
    context_value = await self.context_for_request(request, data)
TypeError: context_for_request() takes 2 positional arguments but 3 were given
```