### PR TITLE
Ugly first implementation of the tracing extension

### DIFF
--- a/ariadne/tracing.py
+++ b/ariadne/tracing.py
@@ -1,0 +1,84 @@
+import datetime
+import time
+from inspect import isawaitable
+
+from graphql import GraphQLResolveInfo, ResponsePath
+
+
+def format_path(path: ResponsePath):
+    elements = []
+    while path:
+        elements.append(path.key)
+        path = path.prev
+    return elements[::-1]
+
+
+class TracingMiddleware:
+    def __init__(self):
+        self.start_date = datetime.datetime.utcnow()
+        self.start_timestamp = time.perf_counter_ns()
+        self.parsing_start_timestamp = self.start_timestamp
+        self.parsing_end_timestamp = self.start_timestamp
+        self.validation_start_timestamp = self.start_timestamp
+        self.validation_end_timestamp = self.start_timestamp
+        self.resolvers = []
+
+    def start_validation(self):
+        self.validation_start_timestamp = time.perf_counter_ns()
+
+    def end_validation(self):
+        self.validation_end_timestamp = time.perf_counter_ns()
+
+    def should_trace(self, info: GraphQLResolveInfo):
+        path = info.path
+        while path:
+            if isinstance(path.key, str) and path.key.startswith('__'):
+                return False
+            path = path.prev
+        if info.parent_type.fields[info.field_name].resolve is None:
+            return False
+        return True
+
+    async def resolve(self, next_, parent, info: GraphQLResolveInfo, **kwargs):
+        if not self.should_trace(info):
+            return next_(parent, info, **kwargs)
+
+        start_timestamp = time.perf_counter_ns()
+        record = {
+            "path": format_path(info.path),
+            "parentType": str(info.parent_type),
+            "fieldName": info.field_name,
+            "returnType": str(info.return_type),
+            "startOffset": start_timestamp - self.start_timestamp,
+        }
+        self.resolvers.append(record)
+        try:
+            result = next_(parent, info, **kwargs)
+            if isawaitable(result):
+                result = await result
+            return result
+        finally:
+            end_timestamp = time.perf_counter_ns()
+            record["duration"] = end_timestamp - start_timestamp
+
+    def extension_data(self):
+        return {
+            "tracing": {
+                "version": 1,
+                "startTime": self.start_date.strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "endTime": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ"),
+                "duration": time.perf_counter_ns() - self.start_timestamp,
+                "parsing": {
+                    "startOffset": self.parsing_start_timestamp - self.start_timestamp,
+                    "duration": self.parsing_end_timestamp
+                    - self.parsing_start_timestamp,
+                },
+                "validation": {
+                    "startOffset": self.validation_start_timestamp
+                    - self.start_timestamp,
+                    "duration": self.validation_end_timestamp
+                    - self.validation_start_timestamp,
+                },
+                "execution": {"resolvers": self.resolvers},
+            }
+        }

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -30,6 +30,7 @@ class GraphQL:
         debug: bool = False,
         logger: Optional[Logger] = None,
         error_formatter: ErrorFormatter = format_error,
+        tracing: bool = False,
     ) -> None:
         self.context_value = context_value
         self.root_value = root_value
@@ -37,6 +38,7 @@ class GraphQL:
         self.logger = logger or default_logger
         self.error_formatter = error_formatter
         self.schema = schema
+        self.tracing = tracing
 
     def __call__(self, environ: dict, start_response: Callable) -> List[bytes]:
         try:
@@ -119,6 +121,7 @@ class GraphQL:
             raise HttpBadRequestError("Request body is not a valid JSON")
 
     def execute_query(self, environ: dict, data: dict) -> GraphQLResult:
+        tracing_requested = environ.get("X_APOLLO_TRACING") is not None
         return graphql_sync(
             self.schema,
             data,
@@ -126,6 +129,7 @@ class GraphQL:
             root_value=self.root_value,
             debug=self.debug,
             logger=self.logger,
+            tracing=self.tracing and tracing_requested,
             error_formatter=self.error_formatter,
         )
 


### PR DESCRIPTION
Implements [Apollo Tracing](https://github.com/apollographql/apollo-tracing) supported by Playground and Apollo Engine.

Tracing is disabled until explicitly allowed. Tracing is only enabled if client explicitly includes `X-Apollo-Tracing` in HTTP headers. Tracing is disabled for the default resolver and for hidden structures (those that start with two underscores) to avoid the huge overhead of tracing an introspection query.