### PR TITLE
Change custom servers doc to "integrations"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `ariadne.asgi.GraphQL` is now an ASGI3 application. ASGI3 is now handled by all ASGI servers.
 - Removed explicit `typing` dependency.
+- Added Flask integration example.
 
 
 ## 0.3.0 (2019-04-08)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,5 +54,5 @@ Table of contents
    local-development
    asgi
    wsgi
-   custom-server
+   integrations
    logo

--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -1,7 +1,18 @@
 Integrations
 ============
 
-Ariadne provides helper functions for the three common operations.
+Ariadne can be used to add GraphQL server to projects developed using other web frameworks like Django or Flask.
+
+Implementation details differ between frameworks, but same steps apply for most of them:
+
+1. Use `ariadne.make_executable_schema` to create executable schema instance.
+2. Create view, route or controller (semantics vary between frameworks) that accepts ``GET`` and ``POST`` requests.
+3. If request was made with ``GET`` method, return response containing GraphQL Playground's HTML.
+4. If request was made with ``POST``, disable any CSRF checks, test that its content type is ``application/json`` then parse its content as JSON. Return ``400 BAD REQUEST`` if this fails.
+5. Call ``ariadne.graphql_sync`` with schema, parsed JSON and any other options that are fit for your implementation.
+5. ``ariadne.graphql_sync`` returns tuple that has two values: ``boolean`` and ``dict``. Use dict as data for JSON response, and boolean for status code. If boolean is ``true``, set response's status code to ``200``, otherwise it should be ``400``
+
+Ariadne provides special functions that abstract away the query execution boilerplate while providing variety of configuration options at same time:
 
 .. cofunction:: ariadne.graphql(schema, data, [root_value=None, context_value=None, debug=False, validation_rules, error_formatter, middleware], **kwargs)
 
@@ -18,13 +29,12 @@ Ariadne provides helper functions for the three common operations.
     This function is an asynchronous coroutine so you will need to ``await`` on the returned value.
 
     .. warning::
-
-        Coroutines will not work under WSGI. If your server uses WSGI (Django and Flask do), see below for a synchronous alternative.
+        Coroutines will not work under WSGI. If your server uses WSGI (Django and Flask do), use ``graphql_sync`` instead.
 
 
 .. function:: ariadne.graphql_sync(schema, data, [root_value=None, context_value=None, debug=False, validation_rules, error_formatter, middleware], **kwargs)
 
-    Parameters are the same as those of the ``graphql`` coroutine above but the function is blocking and the result is returned synchronously.
+    Parameters are the same as those of the ``graphql`` coroutine above but the function is blocking and the result is returned synchronously. Use this function if your site is running under WSGI.
 
 
 .. cofunction:: ariadne.subscribe(schema, data, [root_value=None, context_value=None, debug=False, validation_rules, error_formatter], **kwargs)


### PR DESCRIPTION
This PR renames "custom servers" doc to "integrations", adds Flask example and expands upon general integration process by providing simple step-by-step implementation instruction in addition to our boilerplate for integrators.