### PR TITLE
Add name checks for field and source decorators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Updated `graphql-core-next` to 1.0.3 which has feature parity with GraphQL.js 14.2.1 and better type annotations.
 - `ariadne.asgi.GraphQL` is now an ASGI3 application. ASGI3 is now handled by all ASGI servers.
+- `ObjectType.field` and `SubscriptionType.source` decorators now raise ValueError when used without name argument (eg. `@foo.field`).
 - Removed explicit `typing` dependency.
 - Added Flask integration example.
 

--- a/ariadne/objects.py
+++ b/ariadne/objects.py
@@ -14,6 +14,10 @@ class ObjectType(SchemaBindable):
         self._resolvers = {}
 
     def field(self, name: str) -> Callable[[Resolver], Resolver]:
+        if not isinstance(name, str):
+            raise ValueError(
+                'field decorator should be passed a field name: @foo.field("name")'
+            )
         return self.create_register_resolver(name)
 
     def create_register_resolver(self, name: str) -> Callable[[Resolver], Resolver]:

--- a/ariadne/subscriptions.py
+++ b/ariadne/subscriptions.py
@@ -14,6 +14,10 @@ class SubscriptionType(ObjectType):
         self._subscribers = {}
 
     def source(self, name: str) -> Callable[[Subscriber], Subscriber]:
+        if not isinstance(name, str):
+            raise ValueError(
+                'source decorator should be passed a field name: @foo.source("name")'
+            )
         return self.create_register_subscriber(name)
 
     def create_register_subscriber(

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -46,6 +46,12 @@ def test_field_resolver_can_be_set_using_decorator(schema):
     assert result.data == {"hello": "World"}
 
 
+def test_value_error_is_raised_if_field_decorator_was_used_without_argument():
+    query = ObjectType("Query")
+    with pytest.raises(ValueError):
+        query.field(lambda *_: "World")
+
+
 def test_field_resolver_can_be_set_using_setter(schema):
     query = ObjectType("Query")
     query.set_field("hello", lambda *_: "World")

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -23,9 +23,9 @@ def test_field_source_can_be_set_using_setter(schema):
     async def source(*_):
         yield "test"  # pragma: no cover
 
-    sub = SubscriptionType()
-    sub.set_source("message", source)
-    sub.bind_to_schema(schema)
+    subscription = SubscriptionType()
+    subscription.set_source("message", source)
+    subscription.bind_to_schema(schema)
     field = schema.type_map.get("Subscription").fields["message"]
     assert field.subscribe is source
 
@@ -34,18 +34,27 @@ def test_field_source_can_be_set_using_decorator(schema):
     async def source(*_):
         yield "test"  # pragma: no cover
 
-    sub = SubscriptionType()
-    sub.source("message")(source)
-    sub.bind_to_schema(schema)
+    subscription = SubscriptionType()
+    subscription.source("message")(source)
+    subscription.bind_to_schema(schema)
     field = schema.type_map.get("Subscription").fields["message"]
     assert field.subscribe is source
+
+
+def test_value_error_is_raised_if_source_decorator_was_used_without_argument():
+    async def source(*_):
+        yield "test"  # pragma: no cover
+
+    subscription = SubscriptionType()
+    with pytest.raises(ValueError):
+        subscription.source(source)
 
 
 def test_attempt_bind_subscription_to_undefined_field_raises_error(schema):
     async def source(*_):
         yield "test"  # pragma: no cover
 
-    sub_map = SubscriptionType()
-    sub_map.set_source("fake", source)
+    subscription = SubscriptionType()
+    subscription.set_source("fake", source)
     with pytest.raises(ValueError):
-        sub_map.bind_to_schema(schema)
+        subscription.bind_to_schema(schema)


### PR DESCRIPTION
This PR adds checks to `field` and `source` decorators that raise `ValueError` when name argument is not `str`:

```
@foo.field
def resolve_smth(*_):
    ...
```

<img width="460" alt="Zrzut ekranu 2019-05-7 o 12 37 53" src="https://user-images.githubusercontent.com/750553/57293551-58ab4b80-70c5-11e9-9b56-c2827a2fb7d0.png">

Fixes #151 