### PR TITLE
Set scalar default literal parser when value parser is set

### DIFF
--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -1,5 +1,11 @@
 from typing import Optional, cast
 
+from graphql.language.ast import (
+    BooleanValueNode,
+    FloatValueNode,
+    IntValueNode,
+    StringValueNode,
+)
 from graphql.type import (
     GraphQLNamedType,
     GraphQLScalarLiteralParser,
@@ -36,6 +42,8 @@ class ScalarType(SchemaBindable):
 
     def set_value_parser(self, f: GraphQLScalarValueParser) -> GraphQLScalarValueParser:
         self._parse_value = f
+        if not self._parse_literal:
+            self._parse_literal = create_default_literal_parser(f)
         return f
 
     def set_literal_parser(
@@ -70,3 +78,15 @@ class ScalarType(SchemaBindable):
                 "%s is defined in the schema, but it is instance of %s (expected %s)"
                 % (self.name, type(graphql_type).__name__, GraphQLScalarType.__name__)
             )
+
+
+SCALAR_AST_NODES = (BooleanValueNode, FloatValueNode, IntValueNode, StringValueNode)
+
+
+def create_default_literal_parser(
+    value_parser: GraphQLScalarValueParser
+) -> GraphQLScalarLiteralParser:
+    def default_literal_parser(ast):
+        return value_parser(ast.value)
+
+    return default_literal_parser

--- a/tests/test_custom_scalars.py
+++ b/tests/test_custom_scalars.py
@@ -36,7 +36,7 @@ def resolve_test_input(*_, value):
 
 
 @query.field("testInputValueType")
-def resolve_test_input(*_, value):
+def resolve_test_input_type(*_, value):
     return value
 
 


### PR DESCRIPTION
This PR sets default literal parser calling value parser with `ast.value`, saving some boilerplate when writing simple custom scalars.

Fixes #26