### PR TITLE
Remove unused format_errors utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated `graphql-core-next` to 1.0.3 which has feature parity with GraphQL.js 14.2.1 and better type annotations.
 - `ariadne.asgi.GraphQL` is now an ASGI3 application. ASGI3 is now handled by all ASGI servers.
 - `ObjectType.field` and `SubscriptionType.source` decorators now raise ValueError when used without name argument (eg. `@foo.field`).
+- Removed unused `format_errors` utility function and renamed `ariadne.format_errors` module to `ariadne.format_error`.
 - Removed explicit `typing` dependency.
 - Added Flask integration example.
 

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,6 +1,6 @@
 from .enums import EnumType
 from .executable_schema import make_executable_schema
-from .format_errors import format_error, format_errors, get_error_extension
+from .format_error import format_error, get_error_extension
 from .graphql import graphql, graphql_sync, subscribe
 from .interfaces import InterfaceType
 from .load_schema import load_schema_from_path
@@ -35,7 +35,6 @@ __all__ = [
     "default_resolver",
     "fallback_resolvers",
     "format_error",
-    "format_errors",
     "get_error_extension",
     "gql",
     "graphql",

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -9,7 +9,7 @@ from starlette.websockets import WebSocket, WebSocketState, WebSocketDisconnect
 
 from .constants import DATA_TYPE_JSON, PLAYGROUND_HTML
 from .exceptions import HttpBadRequestError, HttpError
-from .format_errors import format_error
+from .format_error import format_error
 from .graphql import graphql, subscribe
 from .types import ErrorFormatter
 

--- a/ariadne/format_error.py
+++ b/ariadne/format_error.py
@@ -8,14 +8,6 @@ from graphql import ExecutionResult, GraphQLError
 from .types import ErrorFormatter
 
 
-def format_errors(
-    result: ExecutionResult, format_error: ErrorFormatter, debug: bool = False
-) -> List[dict]:
-    if result.errors:
-        return [format_error(e, debug) for e in result.errors]
-    return []
-
-
 def format_error(error: GraphQLError, debug: bool = False) -> dict:
     formatted = error.formatted
     if debug:

--- a/ariadne/format_error.py
+++ b/ariadne/format_error.py
@@ -3,9 +3,7 @@ from traceback import format_exception
 
 from typing import List, Optional, Union, cast
 
-from graphql import ExecutionResult, GraphQLError
-
-from .types import ErrorFormatter
+from graphql import GraphQLError
 
 
 def format_error(error: GraphQLError, debug: bool = False) -> dict:

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -5,7 +5,7 @@ from graphql import ExecutionResult, GraphQLError, GraphQLSchema, parse
 from graphql.execution import Middleware
 from graphql.validation.rules import RuleType
 
-from .format_errors import format_error
+from .format_error import format_error
 from .types import ErrorFormatter, GraphQLResult, SubscriptionResult
 
 

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -13,7 +13,7 @@ from .constants import (
     PLAYGROUND_HTML,
 )
 from .exceptions import HttpBadRequestError, HttpError, HttpMethodNotAllowedError
-from .format_errors import format_error
+from .format_error import format_error
 from .graphql import graphql_sync
 from .types import ErrorFormatter, GraphQLResult
 

--- a/tests/test_error_formatting.py
+++ b/tests/test_error_formatting.py
@@ -5,8 +5,7 @@ import pytest
 from graphql import graphql_sync
 
 from ariadne import QueryType, make_executable_schema
-from ariadne.format_errors import (
-    format_errors,
+from ariadne.format_error import (
     format_error,
     get_error_extension,
     get_formatted_context,
@@ -42,26 +41,21 @@ def schema(type_defs, resolvers, erroring_resolvers, subscriptions):
     )
 
 
-def test_default_formatter_extracts_errors_from_result(schema):
-    result = graphql_sync(schema, "{ hello }")
-    assert format_errors(result, format_error)
-
-
 def test_default_formatter_is_not_extending_error_by_default(schema):
     result = graphql_sync(schema, "{ hello }")
-    error = format_errors(result, format_error)[0]
+    error = format_error(result.errors[0])
     assert not error.get("extensions")
 
 
 def test_default_formatter_extends_error_with_stacktrace(schema):
     result = graphql_sync(schema, "{ hello }")
-    error = format_errors(result, format_error, debug=True)[0]
+    error = format_error(result.errors[0], debug=True)
     assert error["extensions"]["exception"]["stacktrace"]
 
 
 def test_default_formatter_extends_error_with_context(schema):
     result = graphql_sync(schema, "{ hello }")
-    error = format_errors(result, format_error, debug=True)[0]
+    error = format_error(result.errors[0], debug=True)
     assert error["extensions"]["exception"]["context"]
 
 
@@ -69,7 +63,7 @@ def test_default_formatter_fills_context_with_reprs_of_python_context(
     schema, erroring_resolvers, failing_repr_mock
 ):
     result = graphql_sync(schema, "{ hello }")
-    error = format_errors(result, format_error, debug=True)[0]
+    error = format_error(result.errors[0], debug=True)
     context = error["extensions"]["exception"]["context"]
 
     assert context["test_int"] == repr(123)
@@ -81,7 +75,7 @@ def test_default_formatter_fills_context_with_reprs_of_python_context(
 
 def test_default_formatter_is_not_extending_plain_graphql_error(schema):
     result = graphql_sync(schema, "{ error }")
-    error = format_errors(result, format_error, debug=True)[0]
+    error = format_error(result.errors[0], debug=True)
     assert error["extensions"]["exception"] is None
 
 


### PR DESCRIPTION
This PR removes unused `ariadne.format_errors` utility that simply wrapped loop running `format_error` on `result.errors`. It also renames the module to `ariadne.format_error`.

Fixes #156 