### PR TITLE
Extend schema types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - `ariadne.asgi.GraphQL` is now an ASGI3 application. ASGI3 is now handled by all ASGI servers.
 - `ObjectType.field` and `SubscriptionType.source` decorators now raise ValueError when used without name argument (eg. `@foo.field`).
 - `ScalarType` will now use default literal parser that unpacks `ast.value` and calls value parser if scalar has value parser set.
+- Added support for `extend type` in schema definitions.
 - Removed unused `format_errors` utility function and renamed `ariadne.format_errors` module to `ariadne.format_error`.
 - Removed explicit `typing` dependency.
 - Added Flask integration example.

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -39,11 +39,12 @@ def build_and_extend_schema(ast: DocumentNode) -> GraphQLSchema:
 
 
 EXTENSION_KINDS = [
+    "scalar_type_extension",
     "object_type_extension",
     "interface_type_extension",
-    "input_object_type_extension",
     "union_type_extension",
     "enum_type_extension",
+    "input_object_type_extension",
 ]
 
 

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -1,40 +1,8 @@
 from typing import List, Union
 
-from graphql import GraphQLSchema, DocumentNode, parse, build_ast_schema, extend_schema
+from graphql import DocumentNode, GraphQLSchema, build_ast_schema, extend_schema, parse
 
 from .types import SchemaBindable
-
-
-new_extension_definition_kind = "object_type_extension"
-interface_extension_definition_kind = "interface_type_extension"
-input_object_extension_definition_kind = "input_object_type_extension"
-union_extension_definition_kind = "union_type_extension"
-enum_extension_definition_kind = "enum_type_extension"
-
-extension_kinds = [
-    new_extension_definition_kind,
-    interface_extension_definition_kind,
-    input_object_extension_definition_kind,
-    union_extension_definition_kind,
-    enum_extension_definition_kind,
-]
-
-
-def extract_extensions(ast: DocumentNode) -> DocumentNode:
-    extensions = [node for node in ast.definitions if node.kind in extension_kinds]
-
-    return DocumentNode(definitions=extensions)
-
-
-def build_and_extend_schema(ast: DocumentNode) -> GraphQLSchema:
-    schema = build_ast_schema(ast)
-
-    extension_ast = extract_extensions(ast)
-
-    if extension_ast.definitions:
-        schema = extend_schema(schema, extension_ast)
-
-    return schema
 
 
 def make_executable_schema(
@@ -45,7 +13,6 @@ def make_executable_schema(
         type_defs = join_type_defs(type_defs)
 
     ast_document = parse(type_defs)
-
     schema = build_and_extend_schema(ast_document)
 
     if isinstance(bindables, list):
@@ -59,3 +26,27 @@ def make_executable_schema(
 
 def join_type_defs(type_defs: List[str]) -> str:
     return "\n\n".join(t.strip() for t in type_defs)
+
+
+def build_and_extend_schema(ast: DocumentNode) -> GraphQLSchema:
+    schema = build_ast_schema(ast)
+    extension_ast = extract_extensions(ast)
+
+    if extension_ast.definitions:
+        schema = extend_schema(schema, extension_ast)
+
+    return schema
+
+
+EXTENSION_KINDS = [
+    "object_type_extension",
+    "interface_type_extension",
+    "input_object_type_extension",
+    "union_type_extension",
+    "enum_type_extension",
+]
+
+
+def extract_extensions(ast: DocumentNode) -> DocumentNode:
+    extensions = [node for node in ast.definitions if node.kind in EXTENSION_KINDS]
+    return DocumentNode(definitions=extensions)

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -26,6 +26,17 @@ def extract_extensions(ast: DocumentNode) -> DocumentNode:
     return DocumentNode(definitions=extensions)
 
 
+def build_and_extend_schema(ast: DocumentNode) -> GraphQLSchema:
+    schema = build_ast_schema(ast)
+
+    extension_ast = extract_extensions(ast)
+
+    if extension_ast.definitions:
+        schema = extend_schema(schema, extension_ast)
+
+    return schema
+
+
 def make_executable_schema(
     type_defs: Union[str, List[str]],
     bindables: Union[SchemaBindable, List[SchemaBindable], None] = None,
@@ -35,12 +46,7 @@ def make_executable_schema(
 
     ast_document = parse(type_defs)
 
-    schema = build_ast_schema(ast_document)
-
-    extension_ast = extract_extensions(ast_document)
-
-    if len(extension_ast.definitions) > 0:
-        schema = extend_schema(schema, extension_ast)
+    schema = build_and_extend_schema(ast_document)
 
     if isinstance(bindables, list):
         for obj in bindables:

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -5,18 +5,18 @@ from graphql import GraphQLSchema, DocumentNode, parse, build_ast_schema, extend
 from .types import SchemaBindable
 
 
-newExtensionDefinitionKind = 'object_type_extension'
-interfaceExtensionDefinitionKind = 'interface_type_extension'
-inputObjectExtensionDefinitionKind = 'input_object_type_extension'
-unionExtensionDefinitionKind = 'union_type_extension'
-enumExtensionDefinitionKind = 'enum_type_extension'
+new_extension_definition_kind = "object_type_extension"
+interface_extension_definition_kind = "interface_type_extension"
+input_object_extension_definition_kind = "input_object_type_extension"
+union_extension_definition_kind = "union_type_extension"
+enum_extension_definition_kind = "enum_type_extension"
 
 extension_kinds = [
-    newExtensionDefinitionKind,
-    interfaceExtensionDefinitionKind,
-    inputObjectExtensionDefinitionKind,
-    unionExtensionDefinitionKind,
-    enumExtensionDefinitionKind,
+    new_extension_definition_kind,
+    interface_extension_definition_kind,
+    input_object_extension_definition_kind,
+    union_extension_definition_kind,
+    enum_extension_definition_kind,
 ]
 
 
@@ -39,7 +39,7 @@ def make_executable_schema(
 
     extension_ast = extract_extensions(ast_document)
 
-    if len(extension_ast.definitions):
+    if len(extension_ast.definitions) > 0:
         schema = extend_schema(schema, extension_ast)
 
     if isinstance(bindables, list):

--- a/tests/test_modularization.py
+++ b/tests/test_modularization.py
@@ -25,7 +25,7 @@ duplicate_typedef = """
 
 extend_typedef = """
     extend type Query {
-        admins: User
+        admin: User
     }
 """
 
@@ -97,21 +97,13 @@ def test_different_types_resolver_maps_are_merged_into_executable_schema():
     assert result.data == {"user": {"username": "Joe"}}
 
 
-def test_extending_existing_type():
-    type_defs = [root_typedef, module_typedef, extend_typedef]
-
+def test_defined_type_can_be_extended_with_new_field():
     query = QueryType()
-    query.set_field("admins", lambda *_: Mock(username="Abby"))
-    query.set_field("user", lambda *_: Mock(username="Joe"))
+    query.set_field("admin", lambda *_: Mock(username="Abby"))
 
-    user = ObjectType("User")
+    type_defs = [root_typedef, module_typedef, extend_typedef]
+    schema = make_executable_schema(type_defs, query)
 
-    schema = make_executable_schema(type_defs, [query, user])
-
-    result = graphql_sync(schema, "{ user { username } }")
+    result = graphql_sync(schema, "{ admin { username } }")
     assert result.errors is None
-    assert result.data == {"user": {"username": "Joe"}}
-
-    result = graphql_sync(schema, "{ admins { username } }")
-    assert result.errors is None
-    assert result.data == {"admins": {"username": "Abby"}}
+    assert result.data == {"admin": {"username": "Abby"}}


### PR DESCRIPTION
This PR changes `make_executable_schema` implementation so its possible to use `extend type` in passed SDL, opening new ways for applications modularization.

Fixes #135 #95