### PR TITLE
First working custom directive implementation

### DIFF
--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -1,3 +1,4 @@
+from .directives import DirectiveType
 from .enums import EnumType
 from .executable_schema import make_executable_schema
 from .format_error import format_error, get_error_extension
@@ -20,6 +21,7 @@ from .unions import UnionType
 from .utils import convert_camel_case_to_snake, gql
 
 __all__ = [
+    "DirectiveType",
     "EnumType",
     "FallbackResolversSetter",
     "InterfaceType",

--- a/ariadne/directives.py
+++ b/ariadne/directives.py
@@ -1,0 +1,43 @@
+import enum
+
+from typing import Callable, List, Optional, cast
+
+from graphql.type import GraphQLNamedType, GraphQLObjectType, GraphQLSchema
+
+from .types import Resolver, SchemaBindable
+
+
+class DirectiveType(SchemaBindable):
+    _field: Resolver
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self._field = None
+
+    def field(self, f: Resolver) -> Callable[[Resolver], Resolver]:
+        self._field = f
+        return f
+
+    def bind_to_schema(self, schema: GraphQLSchema) -> None:
+        directive = schema.get_directive(self.name)
+        if not directive:
+            raise ValueError("Directive %s is not defined in the schema" % self.name)
+
+        for object_type in schema.type_map.values():
+            if _type_implements_interface(self.name, object_type):
+                self.bind_resolvers_to_graphql_type(object_type, replace_existing=False)
+
+        for graphql_type in schema.type_map.values():
+            if not isinstance(graphql_type, GraphQLObjectType):
+                continue
+
+            for field in graphql_type.fields.values():
+                if field.ast_node:
+                    for directive in field.ast_node.directives:
+                        if directive.name.value != self.name:
+                            continue
+
+                        arguments = {}
+                        for arg in directive.arguments:
+                            arguments[arg.name.value] = arg.value.value
+                        self._field(field, **arguments)


### PR DESCRIPTION
This PR adds `DirectiveType` to Ariadne that allows developers to define custom field directive that can override field attributes depending on its own:

```
from ariadne import DirectiveType

block_user_agent = DirectiveType("blockUserAgent")

@block_user_agent.field
def field_visitor(field, *, agent):
    original_resolver = field.resolve
    def resolve_user_agent_check(obj, info, **kwargs):
        if agent.lower() not in info.context["request"].headers["user-agent"].lower():
            return original_resolver(obj, info, **kwargs)
        return None

    field.resolve = resolve_user_agent_check
```

Fixes #138