### PR TITLE
Set default enums values in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Added support for `extend type` in schema definitions.
 - Removed unused `format_errors` utility function and renamed `ariadne.format_errors` module to `ariadne.format_error`.
 - Removed explicit `typing` dependency.
-- Added Flask integration example.
+- Fixed default ENUM values not being set.
 
 
 ## 0.3.0 (2019-04-08)

--- a/ariadne/enums.py
+++ b/ariadne/enums.py
@@ -37,3 +37,15 @@ class EnumType(SchemaBindable):
                 "%s is defined in the schema, but it is instance of %s (expected %s)"
                 % (self.name, type(graphql_type).__name__, GraphQLEnumType.__name__)
             )
+
+
+def set_default_enum_values_on_schema(schema: GraphQLSchema):
+    for type_object in schema.type_map.values():
+        if isinstance(type_object, GraphQLEnumType):
+            set_default_enum_values(type_object)
+
+
+def set_default_enum_values(graphql_type: GraphQLEnumType):
+    for key in graphql_type.values:
+        if graphql_type.values[key].value is None:
+            graphql_type.values[key].value = key

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -2,6 +2,7 @@ from typing import List, Union
 
 from graphql import DocumentNode, GraphQLSchema, build_ast_schema, extend_schema, parse
 
+from .enums import set_default_enum_values_on_schema
 from .types import SchemaBindable
 
 
@@ -20,6 +21,8 @@ def make_executable_schema(
             obj.bind_to_schema(schema)
     elif bindables:
         bindables.bind_to_schema(schema)
+
+    set_default_enum_values_on_schema(schema)
 
     return schema
 


### PR DESCRIPTION
This PR updates `make_executable_schema` to set default enum values for unset values.

Fixes #171 