### PR TITLE
Simplify logger configuration

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -1,5 +1,4 @@
 import asyncio
-from logging import Logger
 from typing import Any, AsyncGenerator, Dict, List, Optional, Tuple, cast
 
 from graphql import GraphQLError, GraphQLSchema
@@ -12,7 +11,7 @@ from .constants import DATA_TYPE_JSON, PLAYGROUND_HTML
 from .exceptions import HttpBadRequestError, HttpError
 from .format_error import format_error
 from .graphql import graphql, subscribe
-from .logger import log_error, logger as default_logger
+from .logger import log_error
 from .types import ContextValue, ErrorFormatter, RootValue
 
 GQL_CONNECTION_INIT = "connection_init"  # Client -> Server
@@ -38,14 +37,14 @@ class GraphQL:
         context_value: Optional[ContextValue] = None,
         root_value: Optional[RootValue] = None,
         debug: bool = False,
-        logger: Optional[Logger] = None,
+        logger: Optional[str] = None,
         error_formatter: ErrorFormatter = format_error,
         keepalive: float = None,
     ):
         self.context_value = context_value
         self.root_value = root_value
         self.debug = debug
-        self.logger = logger or default_logger
+        self.logger = logger
         self.error_formatter = error_formatter
         self.keepalive = keepalive
         self.schema = schema

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -1,4 +1,3 @@
-from logging import Logger
 from typing import Any, AsyncGenerator, List, Optional, Sequence, cast
 
 import graphql as _graphql
@@ -6,7 +5,7 @@ from graphql import ExecutionResult, GraphQLError, GraphQLSchema, parse
 from graphql.execution import Middleware
 
 from .format_error import format_error
-from .logger import log_error, logger as default_logger
+from .logger import log_error
 from .types import ErrorFormatter, GraphQLResult, RootValue, SubscriptionResult
 
 
@@ -17,14 +16,12 @@ async def graphql(  # pylint: disable=too-complex,too-many-locals
     context_value: Optional[Any] = None,
     root_value: Optional[RootValue] = None,
     debug: bool = False,
-    logger: Optional[Logger] = None,
+    logger: Optional[str] = None,
     validation_rules=None,
     error_formatter: ErrorFormatter = format_error,
     middleware: Middleware = None,
     **kwargs,
 ) -> GraphQLResult:
-    logger = logger or default_logger
-
     try:
         validate_data(data)
         query, variables, operation_name = (
@@ -72,14 +69,12 @@ def graphql_sync(  # pylint: disable=too-complex,too-many-locals
     context_value: Optional[Any] = None,
     root_value: Optional[RootValue] = None,
     debug: bool = False,
-    logger: Optional[Logger] = None,
+    logger: Optional[str] = None,
     validation_rules=None,
     error_formatter: ErrorFormatter = format_error,
     middleware: Middleware = None,
     **kwargs,
 ) -> GraphQLResult:
-    logger = logger or default_logger
-
     try:
         validate_data(data)
         query, variables, operation_name = (
@@ -127,13 +122,11 @@ async def subscribe(  # pylint: disable=too-complex, too-many-locals
     context_value: Optional[Any] = None,
     root_value: Optional[RootValue] = None,
     debug: bool = False,
-    logger: Optional[Logger] = None,
+    logger: Optional[str] = None,
     validation_rules=None,
     error_formatter: ErrorFormatter = format_error,
     **kwargs,
 ) -> SubscriptionResult:
-    logger = logger or default_logger
-
     try:
         validate_data(data)
         query, variables, operation_name = (
@@ -176,7 +169,7 @@ async def subscribe(  # pylint: disable=too-complex, too-many-locals
 
 
 def handle_query_result(
-    result, *, logger=default_logger, error_formatter=format_error, debug=False
+    result, *, logger=None, error_formatter=format_error, debug=False
 ) -> GraphQLResult:
     response = {"data": result.data}
     if result.errors:

--- a/ariadne/logger.py
+++ b/ariadne/logger.py
@@ -1,15 +1,14 @@
 import logging
-from logging import Logger
+from typing import Optional
 
 from .utils import unwrap_graphql_error
 
 
-logger = logging.getLogger("ariadne")
-
-
-def log_error(error: Exception, logger: Logger):
+def log_error(error: Exception, logger_name: Optional[str]):
     original_error = unwrap_graphql_error(error)
     if original_error and original_error is not error:
         error.__suppress_context__ = True
         error.__cause__ = original_error
+
+    logger = logging.getLogger(logger_name or "ariadne")
     logger.error(error, exc_info=error)

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -1,5 +1,4 @@
 import json
-from logging import Logger
 from typing import Any, Callable, List, Optional
 
 from graphql import GraphQLError, GraphQLSchema
@@ -16,7 +15,6 @@ from .constants import (
 from .exceptions import HttpBadRequestError, HttpError, HttpMethodNotAllowedError
 from .format_error import format_error
 from .graphql import graphql_sync
-from .logger import logger as default_logger
 from .types import ContextValue, ErrorFormatter, GraphQLResult, RootValue
 
 
@@ -28,13 +26,13 @@ class GraphQL:
         context_value: Optional[ContextValue] = None,
         root_value: Optional[RootValue] = None,
         debug: bool = False,
-        logger: Optional[Logger] = None,
+        logger: Optional[str] = None,
         error_formatter: ErrorFormatter = format_error,
     ) -> None:
         self.context_value = context_value
         self.root_value = root_value
         self.debug = debug
-        self.logger = logger or default_logger
+        self.logger = logger
         self.error_formatter = error_formatter
         self.schema = schema
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,7 +1,14 @@
 Logging
 =======
 
-Ariadne logs all errors using default ``ariadne`` logger. To use custom logger instead, pass it to ``logger`` option. This option is supported by following functions and objects:
+Ariadne logs all errors using default ``ariadne`` logger. To define custom logger instead, pass its name to ``logger`` option::
+
+    from ariadne.wsgi import GraphQL
+    from .schema import schema
+
+    app = GraphQL(schema, logger="admin.graphql")
+
+``logger`` option is supported by following functions and objects:
 
 - ``ariadne.graphql``
 - ``ariadne.graphql_sync``

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -69,11 +69,18 @@ def execute_failing_query(app):
     )
 
 
-def test_custom_logger_is_used_to_log_error(schema):
-    logger = Mock(error=Mock(return_value=True))
-    app = GraphQL(schema, logger=logger)
+def test_default_logger_is_used_to_log_error_if_custom_is_not_set(schema, mocker):
+    logging_mock = mocker.patch("ariadne.logger.logging")
+    app = GraphQL(schema)
     execute_failing_query(app)
-    logger.error.assert_called_once()
+    logging_mock.getLogger.assert_called_once_with("ariadne")
+
+
+def test_custom_logger_is_used_to_log_error(schema, mocker):
+    logging_mock = mocker.patch("ariadne.logger.logging")
+    app = GraphQL(schema, logger="custom")
+    execute_failing_query(app)
+    logging_mock.getLogger.assert_called_once_with("custom")
 
 
 def test_custom_error_formatter_is_used_to_format_error(schema):


### PR DESCRIPTION
This PR simplifies loggers configuration so `logger` option is used for logger name, not `logging.Logger` instance.