### PR TITLE
Fix django integration example to mention django app

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -49,7 +49,14 @@ Django integration
 
 Ariadne ships with ``ariadne.contrib.django`` package that provides ``GraphQLView`` wrapping around GraphQL Playground and query execution::
 
-    # Create executable schema in your schema module...
+    # Add ariadne.contrib.django to INSTALLED_APPS
+    INSTALLED_APPS = [
+        ...
+        "ariadne.contrib.django",
+    ]
+
+
+    # ...create schema module with executable schema in it...
     from ariadne import QueryType
 
     type_defs = """


### PR DESCRIPTION
I've missed the part about adding `ariadne.contrib.django` to `INSTALLED_APPS`, wich is kind of important because we rely on APPS template loader for playground.