### PR TITLE
Clean deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.4.0 (UNRELEASED)
 
-- Updated `graphql-core-next` to 1.0.3 which has feature parity with GraphQL.js 14.2.1 and better type annotations.
+- Updated `graphql-core-next` to 1.0.4 which has feature parity with GraphQL.js 14.3.1 and better type annotations.
 - `ariadne.asgi.GraphQL` is now an ASGI3 application. ASGI3 is now handled by all ASGI servers.
 - `ObjectType.field` and `SubscriptionType.source` decorators now raise ValueError when used without name argument (eg. `@foo.field`).
 - `ScalarType` will now use default literal parser that unpacks `ast.value` and calls value parser if scalar has value parser set.
@@ -15,7 +15,7 @@
 - Added `ariadne.contrib.django` package that provides Django class-based view together with `Date` and `Datetime` scalars.
 - Fixed default ENUM values not being set.
 - Updated project setup so mypy ran in projects with Ariadne dependency run type checks against it's annotations.
-- Updated Starlette to 0.12
+- Updated Starlette to 0.12.0.
 
 
 ## 0.3.0 (2019-04-08)

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -11,7 +11,5 @@ pytest-mock
 python-dateutil
 snapshottest
 requests
-sphinxcontrib-asyncio
-starlette<0.13
 
 pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,12 +4,10 @@
 #
 #    pip-compile requirements-dev.in -o requirements-dev.txt
 #
-alabaster==0.7.12         # via sphinx
 appdirs==1.4.3            # via black
 astroid==2.2.5            # via pylint
 atomicwrites==1.3.0       # via pytest
 attrs==19.1.0             # via black, pytest
-babel==2.6.0              # via sphinx
 black==19.3b0
 certifi==2019.3.9         # via requests
 chardet==3.0.4            # via requests
@@ -17,45 +15,28 @@ click==7.0                # via black, pip-tools
 codecov==2.0.15
 coverage==4.5.3           # via codecov, pytest-cov
 django==2.2.1
-docutils==0.14            # via sphinx
 idna==2.8                 # via requests
-imagesize==1.1.0          # via sphinx
 isort==4.3.18             # via pylint
-jinja2==2.10.1            # via sphinx
 lazy-object-proxy==1.3.1  # via astroid
-markupsafe==1.1.1         # via jinja2
 mccabe==0.6.1             # via pylint
 more-itertools==7.0.0     # via pytest
 mypy-extensions==0.4.1    # via mypy
 mypy==0.701
-packaging==19.0           # via sphinx
 pip-tools==3.6.1
 pluggy==0.9.0             # via pytest
 py==1.8.0                 # via pytest
-pygments==2.3.1           # via sphinx
 pylint==2.3.1
-pyparsing==2.4.0          # via packaging
 pytest-asyncio==0.10.0
 pytest-cov==2.7.1
 pytest-django==3.4.8
 pytest-mock==1.10.4
 pytest==4.4.1
 python-dateutil==2.8.0
-pytz==2019.1              # via babel, django
+pytz==2019.1              # via django
 requests==2.21.0
-six==1.12.0               # via astroid, packaging, pip-tools, pytest, python-dateutil, snapshottest
+six==1.12.0               # via astroid, pip-tools, pytest, python-dateutil, snapshottest
 snapshottest==0.5.0
-snowballstemmer==1.2.1    # via sphinx
-sphinx==2.0.1             # via sphinxcontrib-asyncio
-sphinxcontrib-applehelp==1.0.1  # via sphinx
-sphinxcontrib-asyncio==0.2.0
-sphinxcontrib-devhelp==1.0.1  # via sphinx
-sphinxcontrib-htmlhelp==1.0.2  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.2  # via sphinx
-sphinxcontrib-serializinghtml==1.1.3  # via sphinx
 sqlparse==0.3.0           # via django
-starlette==0.12.0
 termcolor==1.1.0          # via snapshottest
 toml==0.10.0              # via black
 typed-ast==1.3.5          # via astroid, mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt setup.py
 #
-graphql-core-next==1.0.3
+graphql-core-next==1.0.4
 starlette==0.12.0
 typing-extensions==3.6.6

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     packages=["ariadne"],
     package_data={"ariadne": ["py.typed"]},
     install_requires=[
-        "graphql-core-next>=1.0.3",
+        "graphql-core-next>=1.0.4",
         "starlette<0.13",
         "typing_extensions>=3.6.0",
     ],


### PR DESCRIPTION
This PR removes Starlette from `requirements-dev` because its already in main reqs, removes sphinx from deps and bumps GraphQL Core Next to 1.0.4.