### PR TITLE
Make setup.py executable and include templates in dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,8 @@
+include README.md
+include LICENSE
+graft ariadne
+
+global-exclude __pycache__
+global-exclude *.py[co]
+global-exclude .DS_Store
+

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     version="0.4.0",
     url="https://github.com/mirumee/ariadne",
     packages=["ariadne"],
-    package_data={"ariadne": ["py.typed"]},
+    include_package_data=True,
     install_requires=[
         "graphql-core-next>=1.0.4",
         "starlette<0.13",


### PR DESCRIPTION
Closes #180.

```
(saleor-venv) mbp-mikailkocak:ariadne mikailkocak$ rm -R *.egg* && ./setup.py sdist | grep -E 'typed|html'
warning: no previously-included files matching '__pycache__' found anywhere in distribution
warning: no previously-included files matching '*.py[co]' found anywhere in distribution
warning: no previously-included files matching '.DS_Store' found anywhere in distribution
copying ariadne/py.typed -> ariadne-0.4.0/ariadne
copying ariadne/contrib/django/templates/ariadne/graphql_playground.html -> ariadne-0.4.0/ariadne/contrib/django/templates/ariadne
```