### PR TITLE
Make pyLint more lenient

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,11 +3,7 @@ ignore=snapshots
 load-plugins=pylint.extensions.bad_builtin, pylint.extensions.mccabe
 
 [MESSAGES CONTROL]
-disable=C0103, C0111, C0330, C0412, C1001, E1004, I0011, R0201, R0801, R0903, W0232, W0621
-
-[DESIGN]
-max-complexity=6
+disable=C0103, C0111, C0330, C0412, C1001, E1004, I0011, R0101, R0201, R0801, R0903, R0912, R0913, R0914, R0915, R1260, W0232, W0621, W0703
 
 [SIMILARITIES]
 ignore-imports=yes
-min-similarity-lines=8

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -125,7 +125,7 @@ class GraphQL:
             for operation_id in subscriptions:
                 await subscriptions[operation_id].aclose()
 
-    async def handle_websocket_message(  # pylint: disable=too-complex
+    async def handle_websocket_message(
         self,
         message: dict,
         websocket: WebSocket,
@@ -187,7 +187,7 @@ class GraphQL:
                 self.observe_async_results(results, operation_id, websocket)
             )
 
-    async def observe_async_results(  # pylint: disable=too-complex
+    async def observe_async_results(
         self, results: AsyncGenerator, operation_id: str, websocket: WebSocket
     ) -> None:
         try:
@@ -205,7 +205,7 @@ class GraphQL:
                 await websocket.send_json(
                     {"type": GQL_DATA, "id": operation_id, "payload": payload}
                 )
-        except Exception as error:  # pylint: disable=broad-except
+        except Exception as error:
             if not isinstance(error, GraphQLError):
                 error = GraphQLError(str(error), original_error=error)
             log_error(error, self.logger)

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -9,7 +9,7 @@ from .logger import log_error
 from .types import ErrorFormatter, GraphQLResult, RootValue, SubscriptionResult
 
 
-async def graphql(  # pylint: disable=too-complex,too-many-locals
+async def graphql(
     schema: GraphQLSchema,
     data: Any,
     *,
@@ -62,7 +62,7 @@ async def graphql(  # pylint: disable=too-complex,too-many-locals
         )
 
 
-def graphql_sync(  # pylint: disable=too-complex,too-many-locals
+def graphql_sync(
     schema: GraphQLSchema,
     data: Any,
     *,
@@ -115,7 +115,7 @@ def graphql_sync(  # pylint: disable=too-complex,too-many-locals
         )
 
 
-async def subscribe(  # pylint: disable=too-complex, too-many-locals
+async def subscribe(
     schema: GraphQLSchema,
     data: Any,
     *,

--- a/tests/asgi/test_query_execution.py
+++ b/tests/asgi/test_query_execution.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-arguments
 from ariadne.asgi import GQL_CONNECTION_ACK, GQL_ERROR, GQL_CONNECTION_INIT, GQL_START
 
 

--- a/tests/wsgi/conftest.py
+++ b/tests/wsgi/conftest.py
@@ -1,5 +1,3 @@
-# pylint: disable=too-many-arguments, too-complex
-
 import json
 from io import StringIO
 from unittest.mock import Mock

--- a/tests/wsgi/test_query_execution.py
+++ b/tests/wsgi/test_query_execution.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-arguments
 from ariadne.constants import HTTP_STATUS_200_OK, HTTP_STATUS_400_BAD_REQUEST
 
 operation_name = "SayHello"


### PR DESCRIPTION
This PR disables some checks that pylint did but either didn't bother us, or when they did, it would be a massive pain to workaround making it not worth in the first place:

- `broad-except`
- `too-complex`
- `too-many-arguments`
- `too-many-branches`
- `too-many-locals`
- `too-many-nested-blocks`
- `too-many-statements`