### PR TITLE
Add missing constructor return type annotations

### DIFF
--- a/ariadne/exceptions.py
+++ b/ariadne/exceptions.py
@@ -18,7 +18,7 @@ class HttpMethodNotAllowedError(HttpError):
 
 
 class GraphQLFileSyntaxError(Exception):
-    def __init__(self, schema_file, message):
+    def __init__(self, schema_file, message) -> None:
         super().__init__()
         self.message = self.format_message(schema_file, message)
 

--- a/ariadne/objects.py
+++ b/ariadne/objects.py
@@ -62,12 +62,12 @@ class ObjectType(SchemaBindable):
 class QueryType(ObjectType):
     """Convenience class for defining Query type"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("Query")
 
 
 class MutationType(ObjectType):
     """Convenience class for defining Mutation type"""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("Mutation")


### PR DESCRIPTION
This is just minor consistency polish. 😃 

There are a couple constructors defined without a return type.  mypy complains when initializing these objects in a typed codebase.