### PR TITLE
Add pragma no cover to all extension's hooks

### DIFF
--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -35,10 +35,10 @@ class Extension(Protocol):
         pass  # pragma: no cover
 
     def parsing_started(self, query: str):
-        pass
+        pass  # pragma: no cover
 
     def parsing_finished(self, query: str, error: Optional[Exception] = None):
-        pass
+        pass  # pragma: no cover
 
     def validation_started(self, context: ContextValue):
         pass  # pragma: no cover


### PR DESCRIPTION
This PR adds `# pragma: no cover` comments to `parsing_started` and `parsing_finished` hooks in `Extension` type.