### PR TITLE
Call has_errors hook if successfully query had result.errors

### DIFF
--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -239,6 +239,8 @@ def handle_query_result(
         response["errors"] = [error_formatter(error, debug) for error in result.errors]
 
     if extension_manager:
+        if result.errors:
+            extension_manager.has_errors(result.errors)
         add_extensions_to_response(extension_manager, response)
     return True, response
 


### PR DESCRIPTION
This PR updates our extensions system to call `has_errors` if query executed, but had some errors (eg. errors in resolvers). This potentially should enable better error logging in future extensions.