### PR TITLE
Feature/snake case kwargs decorator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# PyCharm
+.idea

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Documentation is available [here](https://ariadnegraphql.org).
 - Loading schema from `.graphql` files.
 - WSGI middleware for implementing GraphQL in existing sites.
 - Opt-in automatic resolvers mapping between `camelCase` and `snake_case`.
+- `@convert_kwargs_snake_case` function decorator for converting `camelCase` kwargs to `snake_case`
 - Build-in simple synchronous dev server for quick GraphQL experimentation and GraphQL Playground.
 - Support for [Apollo GraphQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo).
 - GraphQL syntax validation via `gql()` helper function. Also provides colorization if Apollo GraphQL extension is installed.

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Documentation is available [here](https://ariadnegraphql.org).
 - Defining schema using SDL strings.
 - Loading schema from `.graphql` files.
 - WSGI middleware for implementing GraphQL in existing sites.
-- Opt-in automatic resolvers mapping between `camelCase` and `snake_case`.
-- `@convert_kwargs_snake_case` function decorator for converting `camelCase` kwargs to `snake_case`
+- Opt-in automatic resolvers mapping between `camelCase` and `snake_case`, and a `@convert_kwargs_to_snake_case` function decorator for converting `camelCase` kwargs to `snake_case`.
 - Build-in simple synchronous dev server for quick GraphQL experimentation and GraphQL Playground.
 - Support for [Apollo GraphQL extension for Visual Studio Code](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo).
 - GraphQL syntax validation via `gql()` helper function. Also provides colorization if Apollo GraphQL extension is installed.

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -19,7 +19,7 @@ from .scalars import ScalarType
 from .subscriptions import SubscriptionType
 from .types import SchemaBindable
 from .unions import UnionType
-from .utils import convert_camel_case_to_snake, gql
+from .utils import convert_camel_case_to_snake, gql, convert_kwargs_to_snake_case
 
 __all__ = [
     "EnumType",
@@ -36,6 +36,7 @@ __all__ = [
     "UnionType",
     "combine_multipart_data",
     "convert_camel_case_to_snake",
+    "convert_kwargs_to_snake_case",
     "default_resolver",
     "fallback_resolvers",
     "format_error",

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -19,7 +19,7 @@ from .scalars import ScalarType
 from .subscriptions import SubscriptionType
 from .types import SchemaBindable
 from .unions import UnionType
-from .utils import convert_camel_case_to_snake, gql, convert_kwargs_to_snake_case
+from .utils import convert_camel_case_to_snake, convert_kwargs_to_snake_case, gql
 
 __all__ = [
     "EnumType",

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -27,7 +27,7 @@ def unwrap_graphql_error(
     return error
 
 
-def convert_kwargs_snake_case(func):
+def convert_kwargs_to_snake_case(func):
     def convert_to_snake_case(d):
         converted = {}
         for k, v in d.items():

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -1,3 +1,5 @@
+import asyncio
+from functools import wraps
 from typing import Optional, Union
 
 from graphql import GraphQLError, parse
@@ -23,3 +25,28 @@ def unwrap_graphql_error(
     if isinstance(error, GraphQLError):
         return unwrap_graphql_error(error.original_error)
     return error
+
+
+def convert_kwargs_snake_case(func):
+    def convert_to_snake_case(d):
+        converted = {}
+        for k, v in d.items():
+            if isinstance(v, dict):
+                v = convert_to_snake_case(v)
+            converted[convert_camel_case_to_snake(k)] = v
+        return converted
+
+    if asyncio.iscoroutinefunction(func):
+
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            return await func(*args, **convert_to_snake_case(kwargs))
+
+        return wrapper
+    else:
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            return func(*args, **convert_to_snake_case(kwargs))
+
+        return wrapper

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -1,6 +1,6 @@
 import asyncio
 from functools import wraps
-from typing import Optional, Union
+from typing import Optional, Union, Callable, Dict, Any
 
 from graphql import GraphQLError, parse
 
@@ -27,9 +27,9 @@ def unwrap_graphql_error(
     return error
 
 
-def convert_kwargs_to_snake_case(func):
-    def convert_to_snake_case(d):
-        converted = {}
+def convert_kwargs_to_snake_case(func: Callable) -> Callable:
+    def convert_to_snake_case(d: Dict) -> Dict:
+        converted: Dict = {}
         for k, v in d.items():
             if isinstance(v, dict):
                 v = convert_to_snake_case(v)
@@ -39,13 +39,13 @@ def convert_kwargs_to_snake_case(func):
     if asyncio.iscoroutinefunction(func):
 
         @wraps(func)
-        async def async_wrapper(*args, **kwargs):
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
             return await func(*args, **convert_to_snake_case(kwargs))
 
         return async_wrapper
 
     @wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         return func(*args, **convert_to_snake_case(kwargs))
 
     return wrapper

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -39,14 +39,13 @@ def convert_kwargs_snake_case(func):
     if asyncio.iscoroutinefunction(func):
 
         @wraps(func)
-        async def wrapper(*args, **kwargs):
+        async def async_wrapper(*args, **kwargs):
             return await func(*args, **convert_to_snake_case(kwargs))
 
-        return wrapper
-    else:
+        return async_wrapper
 
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            return func(*args, **convert_to_snake_case(kwargs))
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **convert_to_snake_case(kwargs))
 
-        return wrapper
+    return wrapper

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -19,7 +19,7 @@ def test_decorator_converts_kwargs_to_camel_case():
     )
 
 
-def test_snake_case_input():
+def test_decorator_leaves_snake_case_kwargs_unchanged():
     @convert_kwargs_to_snake_case
     def my_func(*_, **kwargs):
         assert kwargs == {

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -1,0 +1,69 @@
+import pytest
+
+from ariadne.utils import convert_kwargs_snake_case
+
+
+def test_camel_case_input():
+    @convert_kwargs_snake_case
+    def my_func(*_, **kwargs):
+        assert kwargs == {
+            "first_parameter": True,
+            "second_parameter": "value",
+            "nested_parameter": {"first_sub_entry": 1, "second_sub_entry": 2},
+        }
+
+    my_func(
+        firstParameter=True,
+        secondParameter="value",
+        nestedParameter={"firstSubEntry": 1, "secondSubEntry": 2},
+    )
+
+
+def test_snake_case_input():
+    @convert_kwargs_snake_case
+    def my_func(*_, **kwargs):
+        assert kwargs == {
+            "first_parameter": True,
+            "second_parameter": "value",
+            "nested_parameter": {"first_sub_entry": 1, "second_sub_entry": 2},
+        }
+
+    my_func(
+        first_parameter=True,
+        second_parameter="value",
+        nested_parameter={"first_sub_entry": 1, "second_sub_entry": 2},
+    )
+
+
+@pytest.mark.asyncio
+async def test_camel_case_input_async():
+    @convert_kwargs_snake_case
+    async def my_func(*_, **kwargs):
+        assert kwargs == {
+            "first_parameter": True,
+            "second_parameter": "value",
+            "nested_parameter": {"first_sub_entry": 1, "second_sub_entry": 2},
+        }
+
+    await my_func(
+        firstParameter=True,
+        secondParameter="value",
+        nestedParameter={"firstSubEntry": 1, "secondSubEntry": 2},
+    )
+
+
+@pytest.mark.asyncio
+async def test_snake_case_input_async():
+    @convert_kwargs_snake_case
+    async def my_func(*_, **kwargs):
+        assert kwargs == {
+            "first_parameter": True,
+            "second_parameter": "value",
+            "nested_parameter": {"first_sub_entry": 1, "second_sub_entry": 2},
+        }
+
+    await my_func(
+        first_parameter=True,
+        second_parameter="value",
+        nested_parameter={"first_sub_entry": 1, "second_sub_entry": 2},
+    )

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -53,7 +53,7 @@ async def test_camel_case_input_async():
 
 
 @pytest.mark.asyncio
-async def test_snake_case_input_async():
+async def test_decorator_leaves_snake_case_kwargs_unchanged_for_async_resolver():
     @convert_kwargs_to_snake_case
     async def my_func(*_, **kwargs):
         assert kwargs == {

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -3,7 +3,7 @@ import pytest
 from ariadne.utils import convert_kwargs_to_snake_case
 
 
-def test_camel_case_input():
+def test_decorator_converts_kwargs_to_camel_case():
     @convert_kwargs_to_snake_case
     def my_func(*_, **kwargs):
         assert kwargs == {

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ariadne.utils import convert_kwargs_to_snake_case
+from ariadne import convert_kwargs_to_snake_case
 
 
 def test_decorator_converts_kwargs_to_camel_case():

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -36,7 +36,7 @@ def test_decorator_leaves_snake_case_kwargs_unchanged():
 
 
 @pytest.mark.asyncio
-async def test_camel_case_input_async():
+async def test_decorator_converts_kwargs_to_camel_case_for_async_resolver():
     @convert_kwargs_to_snake_case
     async def my_func(*_, **kwargs):
         assert kwargs == {

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -1,10 +1,10 @@
 import pytest
 
-from ariadne.utils import convert_kwargs_snake_case
+from ariadne.utils import convert_kwargs_to_snake_case
 
 
 def test_camel_case_input():
-    @convert_kwargs_snake_case
+    @convert_kwargs_to_snake_case
     def my_func(*_, **kwargs):
         assert kwargs == {
             "first_parameter": True,
@@ -20,7 +20,7 @@ def test_camel_case_input():
 
 
 def test_snake_case_input():
-    @convert_kwargs_snake_case
+    @convert_kwargs_to_snake_case
     def my_func(*_, **kwargs):
         assert kwargs == {
             "first_parameter": True,
@@ -37,7 +37,7 @@ def test_snake_case_input():
 
 @pytest.mark.asyncio
 async def test_camel_case_input_async():
-    @convert_kwargs_snake_case
+    @convert_kwargs_to_snake_case
     async def my_func(*_, **kwargs):
         assert kwargs == {
             "first_parameter": True,
@@ -54,7 +54,7 @@ async def test_camel_case_input_async():
 
 @pytest.mark.asyncio
 async def test_snake_case_input_async():
-    @convert_kwargs_snake_case
+    @convert_kwargs_to_snake_case
     async def my_func(*_, **kwargs):
         assert kwargs == {
             "first_parameter": True,


### PR DESCRIPTION
Added a function decorator for converting all arguments from `camelCase` to `snake_case`, to make the code more pythonic. 

Example usage:
```python
@my_query.field("myField")
@convert_kwargs_to_snake_case
async def resolve_my_field(_: Any, info: GraphQLResolveInfo, nice_snake_cased_argument: str, other_variable: str = None) -> Dict:
    ...
```