### PR TITLE
Update graphql-core-next to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.6.0 (unreleased)
 
+- Updated `graphql-core-next` to 1.1.1 which has feature parity with GraphQL.js v14.4.0.
 - Added basic extensions system to the `ariadne.graphql.graphql`. Currently only available in the `ariadne.asgi.GraphQL` app.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.6.0 (unreleased)
 
-- Updated `graphql-core-next` to 1.1.1 which has feature parity with GraphQL.js v14.4.0.
+- Updated `graphql-core-next` to 1.1.1 which has feature parity with GraphQL.js 14.4.0.
 - Added basic extensions system to the `ariadne.graphql.graphql`. Currently only available in the `ariadne.asgi.GraphQL` app.
 
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Documentation is available [here](https://ariadnegraphql.org).
 ## Features
 
 - Simple, quick to learn and easy to memorize API.
-- Compatibility with GraphQL.js version 14.2.1.
+- Compatibility with GraphQL.js version 14.4.0.
 - Queries, mutations and input types.
 - Asynchronous resolvers and query execution.
 - Subscriptions.

--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -66,9 +66,9 @@ class ScalarType(SchemaBindable):
             # See mypy bug https://github.com/python/mypy/issues/2427
             graphql_type.serialize = self._serialize  # type: ignore
         if self._parse_value:
-            graphql_type.parse_value = self._parse_value
+            graphql_type.parse_value = self._parse_value  # type: ignore
         if self._parse_literal:
-            graphql_type.parse_literal = self._parse_literal
+            graphql_type.parse_literal = self._parse_literal  # type: ignore
 
     def validate_graphql_type(self, graphql_type: Optional[GraphQLNamedType]) -> None:
         if not graphql_type:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@
 #
 #    pip-compile --output-file requirements.txt setup.py
 #
-graphql-core-next==1.0.4
+graphql-core-next==1.1.1
 python-multipart==0.0.5
+six==1.12.0               # via python-multipart
 starlette==0.12.0
 typing-extensions==3.6.6

--- a/tests/snapshots/snap_test_introspection.py
+++ b/tests/snapshots/snap_test_introspection.py
@@ -147,7 +147,7 @@ snapshots["test_executable_schema_can_be_introspected 1"] = {
                 "possibleTypes": None,
             },
             {
-                "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
+                "description": "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1.",
                 "enumValues": None,
                 "fields": None,
                 "inputFields": None,

--- a/tests/test_custom_scalars.py
+++ b/tests/test_custom_scalars.py
@@ -146,7 +146,7 @@ def test_attempt_deserialize_str_variable_without_valid_date_raises_error():
     assert result.errors is not None
     assert str(result.errors[0]).splitlines()[:1] == [
         "Variable '$value' got invalid value 'invalid string'; "
-        "Expected type DateInput; "
+        "Expected type DateInput. "
         "time data 'invalid string' does not match format '%Y-%m-%d'"
     ]
 
@@ -156,7 +156,7 @@ def test_attempt_deserialize_wrong_type_variable_raises_error():
     result = graphql_sync(schema, parametrized_query, variable_values=variables)
     assert result.errors is not None
     assert str(result.errors[0]).splitlines()[:1] == [
-        "Variable '$value' got invalid value 123; Expected type DateInput; "
+        "Variable '$value' got invalid value 123; Expected type DateInput. "
         "strptime() argument 1 must be str, not int"
     ]
 


### PR DESCRIPTION
This PR updates `graphql-core-next` to 1.1.1, fixing our tests failures.