### PR TITLE
Fixed ASGI forwarding middleware to graphql executor

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from graphql import GraphQLError, GraphQLSchema
-from graphql.execution import Middleware
+from graphql.execution import MiddlewareManager
 from starlette.datastructures import UploadFile
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
@@ -56,7 +56,7 @@ class GraphQL:
         logger: Optional[str] = None,
         error_formatter: ErrorFormatter = format_error,
         extensions: Union[Callable[[Any], ExtensionList], ExtensionList] = None,
-        middleware: Middleware = None,
+        middleware: Optional[MiddlewareManager] = None,
         keepalive: float = None,
     ):
         self.context_value = context_value

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -13,7 +13,7 @@ from typing import (
 )
 
 from graphql import GraphQLError, GraphQLSchema
-from graphql.execution import MiddlewareManager
+from graphql.execution import Middleware
 from starlette.datastructures import UploadFile
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
@@ -56,7 +56,7 @@ class GraphQL:
         logger: Optional[str] = None,
         error_formatter: ErrorFormatter = format_error,
         extensions: Union[Callable[[Any], ExtensionList], ExtensionList] = None,
-        middleware: Optional[MiddlewareManager] = None,
+        middleware: Middleware = None,
         keepalive: float = None,
     ):
         self.context_value = context_value
@@ -124,6 +124,7 @@ class GraphQL:
             logger=self.logger,
             error_formatter=self.error_formatter,
             extensions=extensions,
+            middleware=self.middleware,
         )
         status_code = 200 if success else 400
         return JSONResponse(response, status_code=status_code)


### PR DESCRIPTION
The ASGI app is currently not doing anything with the middleware kwarg. I fixed it to pass it to the `graphql` execution in the `graphql_http_server` function. 