### PR TITLE
Gitignore pip-wheel-metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ eggs/
 lib/
 lib64/
 parts/
+pip-wheel-metadata/
 sdist/
 var/
 wheels/


### PR DESCRIPTION
This is extra file that PIP generates on `pip install`, and shouldn't be commited.