### PR TITLE
Make error formatting utils public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Updated ASGI app disconnection handler to also check client connection state.
 - Fixed ASGI app `context_value` option support for async callables.
 - Updated `middleware` option implementation in ASGI and WSGI apps to accept list of middleware functions or callable returning those.
+- Moved error formatting utils (`get_formatted_error_context`, `get_formatted_error_traceback`, `unwrap_graphql_error`) to public API.
 
 
 ## 0.5.0 (2019-06-07)

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -2,7 +2,12 @@ from .enums import EnumType
 from .executable_schema import make_executable_schema
 from .extensions import ExtensionManager
 from .file_uploads import combine_multipart_data, upload_scalar
-from .format_error import format_error, get_error_extension
+from .format_error import (
+    format_error,
+    get_error_extension,
+    get_formatted_context,
+    get_formatted_traceback,
+)
 from .graphql import graphql, graphql_sync, subscribe
 from .interfaces import InterfaceType
 from .load_schema import load_schema_from_path
@@ -19,7 +24,12 @@ from .scalars import ScalarType
 from .subscriptions import SubscriptionType
 from .types import SchemaBindable
 from .unions import UnionType
-from .utils import convert_camel_case_to_snake, convert_kwargs_to_snake_case, gql
+from .utils import (
+    convert_camel_case_to_snake,
+    convert_kwargs_to_snake_case,
+    gql,
+    unwrap_graphql_error,
+)
 
 __all__ = [
     "EnumType",
@@ -40,6 +50,8 @@ __all__ = [
     "fallback_resolvers",
     "format_error",
     "get_error_extension",
+    "get_formatted_context",
+    "get_formatted_traceback",
     "gql",
     "graphql",
     "graphql_sync",
@@ -49,5 +61,6 @@ __all__ = [
     "resolve_to",
     "snake_case_fallback_resolvers",
     "subscribe",
+    "unwrap_graphql_error",
     "upload_scalar",
 ]

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -5,8 +5,8 @@ from .file_uploads import combine_multipart_data, upload_scalar
 from .format_error import (
     format_error,
     get_error_extension,
-    get_formatted_context,
-    get_formatted_traceback,
+    get_formatted_error_context,
+    get_formatted_error_traceback,
 )
 from .graphql import graphql, graphql_sync, subscribe
 from .interfaces import InterfaceType
@@ -50,8 +50,8 @@ __all__ = [
     "fallback_resolvers",
     "format_error",
     "get_error_extension",
-    "get_formatted_context",
-    "get_formatted_traceback",
+    "get_formatted_error_context",
+    "get_formatted_error_traceback",
     "gql",
     "graphql",
     "graphql_sync",

--- a/ariadne/format_error.py
+++ b/ariadne/format_error.py
@@ -24,19 +24,19 @@ def get_error_extension(error: GraphQLError) -> Optional[dict]:
 
     unwrapped_error = cast(Exception, unwrapped_error)
     return {
-        "stacktrace": get_formatted_traceback(unwrapped_error),
-        "context": get_formatted_context(unwrapped_error),
+        "stacktrace": get_formatted_error_traceback(unwrapped_error),
+        "context": get_formatted_error_context(unwrapped_error),
     }
 
 
-def get_formatted_traceback(error: Exception) -> List[str]:
+def get_formatted_error_traceback(error: Exception) -> List[str]:
     formatted = []
     for line in format_exception(type(error), error, error.__traceback__):
         formatted.extend(line.rstrip().splitlines())
     return formatted
 
 
-def get_formatted_context(error: Exception) -> Optional[dict]:
+def get_formatted_error_context(error: Exception) -> Optional[dict]:
     tb_last = error.__traceback__
     while tb_last and tb_last.tb_next:
         tb_last = tb_last.tb_next

--- a/tests/test_error_formatting.py
+++ b/tests/test_error_formatting.py
@@ -8,7 +8,7 @@ from ariadne import QueryType, make_executable_schema
 from ariadne.format_error import (
     format_error,
     get_error_extension,
-    get_formatted_context,
+    get_formatted_error_context,
 )
 
 
@@ -86,4 +86,4 @@ def test_error_extension_is_not_available_for_error_without_traceback():
 
 def test_incomplete_traceback_is_handled_by_context_extractor():
     error = Mock(__traceback__=None, spec=["__traceback__"])
-    assert get_formatted_context(error) is None
+    assert get_formatted_error_context(error) is None


### PR DESCRIPTION
This PR moves all of `format_error` API to public space, so devs writing custom implementations don't have to dig those out from private API, or invent custom ones.