### PR TITLE
Support extensions for graphql_sync

### DIFF
--- a/ariadne/contrib/tracing/apollotracing.py
+++ b/ariadne/contrib/tracing/apollotracing.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from graphql import GraphQLResolveInfo
 
-from ...types import ContextValue, Extension, ExtensionSync, Resolver
+from ...types import ContextValue, Extension, Resolver
 from .utils import format_path, should_trace
 
 try:
@@ -88,18 +88,7 @@ class ApolloTracingExtension(Extension):
         }
 
 
-class ApolloTracingExtensionSync(ExtensionSync):
-    def __init__(self):
-        self.start_date = None
-        self.start_timestamp = None
-        self.resolvers = []
-
-        self._totals = None
-
-    def request_started(self, context: ContextValue):
-        self.start_date = datetime.datetime.utcnow()
-        self.start_timestamp = perf_counter_ns()
-
+class ApolloTracingExtensionSync(ApolloTracingExtension):
     def resolve(self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs):
         if not should_trace(info):
             result = next_(parent, info, **kwargs)
@@ -120,29 +109,3 @@ class ApolloTracingExtensionSync(ExtensionSync):
         finally:
             end_timestamp = perf_counter_ns()
             record["duration"] = end_timestamp - start_timestamp
-
-    def get_totals(self):
-        if self._totals is None:
-            self._totals = self._get_totals()
-        return self._totals
-
-    def _get_totals(self):
-        return {
-            "start": self.start_date,
-            "end": datetime.datetime.utcnow(),
-            "duration": perf_counter_ns() - self.start_timestamp,
-            "resolvers": self.resolvers,
-        }
-
-    def format(self):
-        totals = self.get_totals()
-
-        return {
-            "tracing": {
-                "version": 1,
-                "startTime": totals["start"].strftime(TIMESTAMP_FORMAT),
-                "endTime": totals["end"].strftime(TIMESTAMP_FORMAT),
-                "duration": totals["duration"],
-                "execution": {"resolvers": totals["resolvers"]},
-            }
-        }

--- a/ariadne/contrib/tracing/opentracing.py
+++ b/ariadne/contrib/tracing/opentracing.py
@@ -7,9 +7,8 @@ from graphql import GraphQLResolveInfo
 from opentracing import Scope, Tracer, global_tracer
 from opentracing.ext import tags
 
-from ...types import ContextValue, Extension, Resolver
+from ...types import ContextValue, Extension, ExtensionSync, Resolver
 from .utils import format_path, should_trace
-
 
 ArgFilter = Callable[[Dict[str, Any], GraphQLResolveInfo], Dict[str, Any]]
 
@@ -71,5 +70,60 @@ class OpenTracingExtension(Extension):
         return self._arg_filter(deepcopy(args), info)
 
 
+class OpenTracingExtensionSync(ExtensionSync):
+    _arg_filter: Optional[ArgFilter]
+    _root_scope: Scope
+    _tracer: Tracer
+
+    def __init__(self, *, arg_filter: Optional[ArgFilter] = None):
+        self._arg_filter = arg_filter
+        self._tracer = global_tracer()
+        self._root_scope = None
+
+    def request_started(self, context: ContextValue):
+        self._root_scope = self._tracer.start_active_span("GraphQL Query")
+        self._root_scope.span.set_tag(tags.COMPONENT, "graphql")
+
+    def request_finished(
+        self, context: ContextValue, error: Optional[Exception] = None
+    ):
+        self._root_scope.close()
+
+    def resolve(self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs):
+        if not should_trace(info):
+            result = next_(parent, info, **kwargs)
+            return result
+
+        with self._tracer.start_active_span(info.field_name) as scope:
+            span = scope.span
+            span.set_tag(tags.COMPONENT, "graphql")
+            span.set_tag("graphql.parentType", info.parent_type.name)
+
+            graphql_path = ".".join(
+                map(str, format_path(info.path))  # pylint: disable=bad-builtin
+            )
+            span.set_tag("graphql.path", graphql_path)
+
+            if kwargs:
+                filtered_kwargs = self.filter_resolver_args(kwargs, info)
+                for kwarg, value in filtered_kwargs.items():
+                    span.set_tag(f"graphql.param.{kwarg}", value)
+
+            result = next_(parent, info, **kwargs)
+            return result
+
+    def filter_resolver_args(
+        self, args: Dict[str, Any], info: GraphQLResolveInfo
+    ) -> Dict[str, Any]:
+        if not self._arg_filter:
+            return args
+
+        return self._arg_filter(deepcopy(args), info)
+
+
 def opentracing_extension(*, arg_filter: Optional[ArgFilter] = None):
     return partial(OpenTracingExtension, arg_filter=arg_filter)
+
+
+def opentracing_extension_sync(*, arg_filter: Optional[ArgFilter] = None):
+    return partial(OpenTracingExtensionSync, arg_filter=arg_filter)

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -23,7 +23,6 @@ from .logger import log_error
 from .types import (
     ErrorFormatter,
     Extension,
-    ExtensionSync,
     GraphQLResult,
     RootValue,
     SubscriptionResult,
@@ -115,7 +114,7 @@ def graphql_sync(
     validation_rules: Optional[Sequence[RuleType]] = None,
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
-    extensions: Optional[List[Type[ExtensionSync]]] = None,
+    extensions: Optional[List[Type[Extension]]] = None,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions)

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -118,6 +118,7 @@ def graphql_sync(
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions)
+
     with extension_manager.request(context_value):
         try:
             validate_data(data)

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -114,59 +114,73 @@ def graphql_sync(
     validation_rules: Optional[Sequence[RuleType]] = None,
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
+    extensions: Optional[List[Type[Extension]]] = None,
     **kwargs,
 ) -> GraphQLResult:
-    try:
-        validate_data(data)
-        query, variables, operation_name = (
-            data["query"],
-            data.get("variables"),
-            data.get("operationName"),
-        )
+    extension_manager = ExtensionManager(extensions)
+    with extension_manager.request(context_value):
+        try:
+            validate_data(data)
+            query, variables, operation_name = (
+                data["query"],
+                data.get("variables"),
+                data.get("operationName"),
+            )
 
-        document = parse_query(query)
+            document = parse_query(query)
 
-        validation_errors = validate_query(schema, document, validation_rules)
-        if validation_errors:
+            validation_errors = validate_query(schema, document, validation_rules)
+            if validation_errors:
+                return handle_graphql_errors(
+                    validation_errors,
+                    logger=logger,
+                    error_formatter=error_formatter,
+                    debug=debug,
+                    extension_manager=extension_manager,
+                )
+
+            if callable(root_value):
+                root_value = root_value(context_value, document)
+                if isawaitable(root_value):
+                    ensure_future(root_value).cancel()
+                    raise RuntimeError(
+                        "Root value resolver can't be asynchronous "
+                        "in synchronous query executor."
+                    )
+
+            result = execute(
+                schema,
+                document,
+                root_value=root_value,
+                context_value=context_value,
+                variable_values=variables,
+                operation_name=operation_name,
+                execution_context_class=ExecutionContext,
+                middleware=extension_manager.as_middleware_manager(middleware),
+                **kwargs,
+            )
+
+            if isawaitable(result):
+                ensure_future(cast(Awaitable[ExecutionResult], result)).cancel()
+                raise RuntimeError(
+                    "GraphQL execution failed to complete synchronously."
+                )
+        except GraphQLError as error:
             return handle_graphql_errors(
-                validation_errors,
+                [error],
                 logger=logger,
                 error_formatter=error_formatter,
                 debug=debug,
+                extension_manager=extension_manager,
             )
-
-        if callable(root_value):
-            root_value = root_value(context_value, document)
-            if isawaitable(root_value):
-                ensure_future(root_value).cancel()
-                raise RuntimeError(
-                    "Root value resolver can't be asynchronous "
-                    "in synchronous query executor."
-                )
-
-        result = execute(
-            schema,
-            document,
-            root_value=root_value,
-            context_value=context_value,
-            variable_values=variables,
-            operation_name=operation_name,
-            execution_context_class=ExecutionContext,
-            middleware=middleware,
-            **kwargs,
-        )
-
-        if isawaitable(result):
-            ensure_future(cast(Awaitable[ExecutionResult], result)).cancel()
-            raise RuntimeError("GraphQL execution failed to complete synchronously.")
-    except GraphQLError as error:
-        return handle_graphql_errors(
-            [error], logger=logger, error_formatter=error_formatter, debug=debug
-        )
-    else:
-        return handle_query_result(
-            result, logger=logger, error_formatter=error_formatter, debug=debug
-        )
+        else:
+            return handle_query_result(
+                result,
+                logger=logger,
+                error_formatter=error_formatter,
+                debug=debug,
+                extension_manager=extension_manager,
+            )
 
 
 async def subscribe(

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -23,6 +23,7 @@ from .logger import log_error
 from .types import (
     ErrorFormatter,
     Extension,
+    ExtensionSync,
     GraphQLResult,
     RootValue,
     SubscriptionResult,
@@ -114,7 +115,7 @@ def graphql_sync(
     validation_rules: Optional[Sequence[RuleType]] = None,
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
-    extensions: Optional[List[Type[Extension]]] = None,
+    extensions: Optional[List[Type[ExtensionSync]]] = None,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions)

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -49,6 +49,26 @@ class Extension(Protocol):
         return {}  # pragma: no cover
 
 
+class ExtensionSync(Protocol):
+    def request_started(self, context: ContextValue):
+        pass  # pragma: no cover
+
+    def request_finished(
+        self, context: ContextValue, error: Optional[Exception] = None
+    ):
+        pass  # pragma: no cover
+
+    def resolve(self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs):
+        result = next_(parent, info, **kwargs)
+        return result
+
+    def has_errors(self, errors: List[GraphQLError]):
+        pass  # pragma: no cover
+
+    def format(self) -> dict:
+        return {}  # pragma: no cover
+
+
 class SchemaBindable(Protocol):
     def bind_to_schema(self, schema: GraphQLSchema) -> None:
         pass  # pragma: no cover

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -49,24 +49,10 @@ class Extension(Protocol):
         return {}  # pragma: no cover
 
 
-class ExtensionSync(Protocol):
-    def request_started(self, context: ContextValue):
-        pass  # pragma: no cover
-
-    def request_finished(
-        self, context: ContextValue, error: Optional[Exception] = None
-    ):
-        pass  # pragma: no cover
-
+class ExtensionSync(Extension):
     def resolve(self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs):
         result = next_(parent, info, **kwargs)
         return result
-
-    def has_errors(self, errors: List[GraphQLError]):
-        pass  # pragma: no cover
-
-    def format(self) -> dict:
-        return {}  # pragma: no cover
 
 
 class SchemaBindable(Protocol):

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -51,8 +51,7 @@ class Extension(Protocol):
 
 class ExtensionSync(Extension):
     def resolve(self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs):
-        result = next_(parent, info, **kwargs)
-        return result
+        return next_(parent, info, **kwargs)
 
 
 class SchemaBindable(Protocol):

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -19,9 +19,9 @@ from .exceptions import HttpBadRequestError, HttpError, HttpMethodNotAllowedErro
 from .file_uploads import combine_multipart_data
 from .format_error import format_error
 from .graphql import graphql_sync
-from .types import ContextValue, ErrorFormatter, ExtensionSync, GraphQLResult, RootValue
+from .types import ContextValue, ErrorFormatter, Extension, GraphQLResult, RootValue
 
-ExtensionList = Optional[List[Type[ExtensionSync]]]
+ExtensionList = Optional[List[Type[Extension]]]
 Extensions = Union[
     Callable[[Any, Optional[ContextValue]], ExtensionList], ExtensionList
 ]

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -185,8 +185,7 @@ class GraphQL:
         self, environ: dict, context: Optional[ContextValue]
     ) -> ExtensionList:
         if callable(self.extensions):
-            extensions = self.extensions(environ, context)
-            return extensions
+            return self.extensions(environ, context)
         return self.extensions
 
     def get_middleware_for_request(

--- a/requirements-dev.in
+++ b/requirements-dev.in
@@ -13,5 +13,6 @@ pytest-mock
 python-dateutil
 snapshottest
 requests
+werkzeug
 
 pip-tools

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,5 +50,6 @@ typing-extensions==3.7.4  # via mypy
 urllib3==1.25.3           # via requests
 wasmer==0.3.0             # via fastdiff
 wcwidth==0.1.7            # via pytest
+werkzeug==0.15.5
 wrapt==1.11.2             # via astroid
 zipp==0.5.2               # via importlib-metadata

--- a/tests/test_extensions_sync.py
+++ b/tests/test_extensions_sync.py
@@ -1,0 +1,55 @@
+from unittest.mock import Mock
+
+from ariadne import ExtensionManager
+from ariadne.types import ExtensionSync as Extension
+
+
+context: dict = {}
+exception = ValueError()
+query = "{ test }"
+
+
+def test_request_started_event_is_called_by_extension_manager():
+    extension = Mock(spec=Extension)
+    manager = ExtensionManager([Mock(return_value=extension)])
+    with manager.request(context):
+        pass
+
+    extension.request_started.assert_called_once_with(context)
+
+
+def test_request_finished_event_is_called_by_extension_manager():
+    extension = Mock(spec=Extension)
+    manager = ExtensionManager([Mock(return_value=extension)])
+    with manager.request(context):
+        pass
+
+    extension.request_finished.assert_called_once_with(context)
+
+
+def test_request_finished_event_is_called_with_error():
+    extension = Mock(spec=Extension)
+    manager = ExtensionManager([Mock(return_value=extension)])
+    try:
+        with manager.request(context):
+            raise exception
+    except:  # pylint: disable=bare-except
+        pass
+
+    extension.request_finished.assert_called_once_with(context, exception)
+
+
+def test_has_errors_event_is_called_with_errors_list():
+    extension = Mock(spec=Extension)
+    manager = ExtensionManager([Mock(return_value=extension)])
+    manager.has_errors([exception])
+    extension.has_errors.assert_called_once_with([exception])
+
+
+def test_extensions_are_formatted():
+    extensions = [
+        Mock(spec=Extension, format=Mock(return_value={"a": 1})),
+        Mock(spec=Extension, format=Mock(return_value={"b": 2})),
+    ]
+    manager = ExtensionManager([Mock(return_value=ext) for ext in extensions])
+    assert manager.format() == {"a": 1, "b": 2}

--- a/tests/tracing/test_apollotracing_sync.py
+++ b/tests/tracing/test_apollotracing_sync.py
@@ -1,0 +1,54 @@
+import pytest
+from freezegun import freeze_time
+from graphql import get_introspection_query
+
+from ariadne import graphql_sync as graphql
+from ariadne.contrib.tracing.apollotracing import (
+    ApolloTracingExtensionSync as ApolloTracingExtension,
+)
+
+
+@pytest.mark.asyncio
+async def test_apollotracing_extension_causes_no_errors_in_query_execution(schema):
+    _, result = graphql(
+        schema, {"query": "{ status }"}, extensions=[ApolloTracingExtension]
+    )
+    assert result["data"] == {"status": True}
+
+
+@pytest.fixture
+def freeze_microtime(mocker):
+    mocker.patch(
+        "ariadne.contrib.tracing.apollotracing.perf_counter_ns", return_value=2
+    )
+
+
+@freeze_time("2012-01-14 03:21:34")
+@pytest.mark.asyncio
+async def test_apollotracing_extension_adds_tracing_data_to_result_extensions(
+    schema, freeze_microtime, snapshot  # pylint: disable=unused-argument
+):
+    _, result = graphql(
+        schema, {"query": "{ status }"}, extensions=[ApolloTracingExtension]
+    )
+    snapshot.assert_match(result)
+
+
+@freeze_time("2012-01-14 03:21:34")
+@pytest.mark.asyncio
+async def test_apollotracing_extension_handles_exceptions_in_resolvers(
+    schema, freeze_microtime, snapshot  # pylint: disable=unused-argument
+):
+    _, result = graphql(
+        schema, {"query": "{ testError }"}, extensions=[ApolloTracingExtension]
+    )
+    snapshot.assert_match(result["data"])
+
+
+@pytest.mark.asyncio
+async def test_apollotracing_extension_doesnt_break_introspection(schema):
+    introspection_query = get_introspection_query(descriptions=True)
+    _, result = graphql(
+        schema, {"query": introspection_query}, extensions=[ApolloTracingExtension]
+    )
+    assert "errors" not in result

--- a/tests/tracing/test_opentracing_sync.py
+++ b/tests/tracing/test_opentracing_sync.py
@@ -1,0 +1,106 @@
+from unittest.mock import ANY, call
+
+import pytest
+from graphql import get_introspection_query
+from opentracing.ext import tags
+
+from ariadne import graphql_sync as graphql
+from ariadne.contrib.tracing.opentracing import (
+    OpenTracingExtensionSync as OpenTracingExtension,
+    opentracing_extension_sync as opentracing_extension,
+)
+
+
+@pytest.fixture
+def global_tracer_mock(mocker):
+    return mocker.patch("ariadne.contrib.tracing.opentracing.global_tracer")
+
+
+@pytest.fixture
+def active_span_mock(global_tracer_mock):
+    return global_tracer_mock.return_value.start_active_span.return_value
+
+
+def test_opentracing_extension_causes_no_errors_in_query_execution(schema):
+    _, result = graphql(
+        schema,
+        {"query": '{ status hello(name: "Bob") }'},
+        extensions=[OpenTracingExtension],
+    )
+    assert result == {"data": {"hello": "Hello, Bob!", "status": True}}
+
+
+def test_opentracing_extension_uses_global_tracer(schema, global_tracer_mock):
+    graphql(
+        schema,
+        {"query": '{ status hello(name: "Bob") }'},
+        extensions=[OpenTracingExtension],
+    )
+    global_tracer_mock.assert_called_once()
+
+
+def test_opentracing_extension_creates_span_for_query_root(schema, global_tracer_mock):
+    graphql(schema, {"query": "{ status }"}, extensions=[OpenTracingExtension])
+    global_tracer_mock.return_value.start_active_span.assert_any_call("GraphQL Query")
+
+
+def test_opentracing_extension_creates_span_for_field(schema, global_tracer_mock):
+    graphql(schema, {"query": "{ status }"}, extensions=[OpenTracingExtension])
+    global_tracer_mock.return_value.start_active_span.assert_any_call("status")
+
+
+def test_opentracing_extension_sets_graphql_component_tag_on_root_span(
+    schema, active_span_mock
+):
+    graphql(
+        schema,
+        {"query": '{ status hello(name: "Bob") }'},
+        extensions=[OpenTracingExtension],
+    )
+    active_span_mock.span.set_tag.assert_called_once_with(tags.COMPONENT, "graphql")
+
+
+def test_opentracing_extension_calls_custom_arg_filter(schema, mocker):
+    arg_filter = mocker.Mock(return_value={})
+    graphql(
+        schema,
+        {"query": '{ hello(name: "Bob") }'},
+        extensions=[opentracing_extension(arg_filter=arg_filter)],
+    )
+    arg_filter.assert_called_once_with({"name": "Bob"}, ANY)
+
+
+def test_opentracing_extension_sets_filtered_args_on_span(
+    schema, active_span_mock, mocker
+):
+    arg_filter = mocker.Mock(return_value={"name": "[filtered]"})
+    graphql(
+        schema,
+        {"query": '{ hello(name: "Bob") }'},
+        extensions=[opentracing_extension(arg_filter=arg_filter)],
+    )
+
+    span_mock = active_span_mock.__enter__.return_value.span
+    span_mock.set_tag.assert_has_calls(
+        [
+            call("component", "graphql"),
+            call("graphql.parentType", "Query"),
+            call("graphql.path", "hello"),
+            call("graphql.param.name", "[filtered]"),
+        ]
+    )
+
+
+def test_opentracing_extension_handles_errors_in_resolvers(schema):
+    _, result = graphql(
+        schema, {"query": "{ testError status }"}, extensions=[OpenTracingExtension]
+    )
+    assert result["data"] == {"testError": None, "status": True}
+
+
+def test_opentracing_extension_doesnt_break_introspection(schema):
+    introspection_query = get_introspection_query(descriptions=True)
+    _, result = graphql(
+        schema, {"query": introspection_query}, extensions=[OpenTracingExtension]
+    )
+    assert "errors" not in result

--- a/tests/wsgi/conftest.py
+++ b/tests/wsgi/conftest.py
@@ -1,10 +1,16 @@
 import json
 from io import StringIO
 from unittest.mock import Mock
+from werkzeug.test import Client
 
 import pytest
 
 from ariadne.wsgi import GraphQL, GraphQLMiddleware
+
+
+@pytest.fixture
+def client(app):
+    return Client(app)
 
 
 @pytest.fixture


### PR DESCRIPTION
(This is a work in progress.)

These changes seemed to work with the following test:

```
from ariadne.types import ExtensionSync
...
class TimestampExtension(ExtensionSync):
    def format(self):
        return {"timestamp": datetime.now().isoformat()}
...
graphql_sync(
    schema,
    ...
    extensions=[TimestampExtension]
```

This also worked if I left off extensions as a kwarg in graphql_sync's call to execute so there may be other test cases that should be checked with this. Is this sufficient to support extensions for synchronous calls or is there another issue that needs to be handled in order for this to work correctly?