### PR TITLE
Misc extensions cleanups

### DIFF
--- a/ariadne/contrib/tracing/opentracing.py
+++ b/ariadne/contrib/tracing/opentracing.py
@@ -27,9 +27,7 @@ class OpenTracingExtension(Extension):
         self._root_scope = self._tracer.start_active_span("GraphQL Query")
         self._root_scope.span.set_tag(tags.COMPONENT, "graphql")
 
-    def request_finished(
-        self, context: ContextValue, error: Optional[Exception] = None
-    ):
+    def request_finished(self, context: ContextValue):
         self._root_scope.close()
 
     async def resolve(

--- a/ariadne/extensions.py
+++ b/ariadne/extensions.py
@@ -30,11 +30,7 @@ class ExtensionManager:
             ext.request_started(context)
         try:
             yield
-        except Exception as e:
-            for ext in self.extensions_reversed:
-                ext.request_finished(context, e)
-            raise
-        else:
+        finally:
             for ext in self.extensions_reversed:
                 ext.request_finished(context)
 

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -29,9 +29,7 @@ class Extension(Protocol):
     def request_started(self, context: ContextValue):
         pass  # pragma: no cover
 
-    def request_finished(
-        self, context: ContextValue, error: Optional[Exception] = None
-    ):
+    def request_finished(self, context: ContextValue):
         pass  # pragma: no cover
 
     async def resolve(

--- a/tests/test_extensions_sync.py
+++ b/tests/test_extensions_sync.py
@@ -1,16 +1,15 @@
 from unittest.mock import Mock
 
-from ariadne import ExtensionManager
-from ariadne.types import ExtensionSync as Extension
+from ariadne import ExtensionManager, graphql_sync
+from ariadne.types import ExtensionSync
 
 
 context: dict = {}
 exception = ValueError()
-query = "{ test }"
 
 
 def test_request_started_event_is_called_by_extension_manager():
-    extension = Mock(spec=Extension)
+    extension = Mock(spec=ExtensionSync)
     manager = ExtensionManager([Mock(return_value=extension)])
     with manager.request(context):
         pass
@@ -19,7 +18,7 @@ def test_request_started_event_is_called_by_extension_manager():
 
 
 def test_request_finished_event_is_called_by_extension_manager():
-    extension = Mock(spec=Extension)
+    extension = Mock(spec=ExtensionSync)
     manager = ExtensionManager([Mock(return_value=extension)])
     with manager.request(context):
         pass
@@ -27,20 +26,8 @@ def test_request_finished_event_is_called_by_extension_manager():
     extension.request_finished.assert_called_once_with(context)
 
 
-def test_request_finished_event_is_called_with_error():
-    extension = Mock(spec=Extension)
-    manager = ExtensionManager([Mock(return_value=extension)])
-    try:
-        with manager.request(context):
-            raise exception
-    except:  # pylint: disable=bare-except
-        pass
-
-    extension.request_finished.assert_called_once_with(context, exception)
-
-
 def test_has_errors_event_is_called_with_errors_list():
-    extension = Mock(spec=Extension)
+    extension = Mock(spec=ExtensionSync)
     manager = ExtensionManager([Mock(return_value=extension)])
     manager.has_errors([exception])
     extension.has_errors.assert_called_once_with([exception])
@@ -48,8 +35,15 @@ def test_has_errors_event_is_called_with_errors_list():
 
 def test_extensions_are_formatted():
     extensions = [
-        Mock(spec=Extension, format=Mock(return_value={"a": 1})),
-        Mock(spec=Extension, format=Mock(return_value={"b": 2})),
+        Mock(spec=ExtensionSync, format=Mock(return_value={"a": 1})),
+        Mock(spec=ExtensionSync, format=Mock(return_value={"b": 2})),
     ]
     manager = ExtensionManager([Mock(return_value=ext) for ext in extensions])
     assert manager.format() == {"a": 1, "b": 2}
+
+
+def test_default_extension_hooks_dont_interrupt_query_execution(schema):
+    _, response = graphql_sync(
+        schema, {"query": "{ status }"}, extensions=[ExtensionSync]
+    )
+    assert response["data"] == {"status": True}

--- a/tests/tracing/snapshots/snap_test_apollotracing_sync.py
+++ b/tests/tracing/snapshots/snap_test_apollotracing_sync.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['test_apollotracing_extension_adds_tracing_data_to_result_extensions 1'] = {
+    'data': {
+        'status': True
+    },
+    'extensions': {
+        'tracing': {
+            'duration': 0,
+            'endTime': '2012-01-14T03:21:34.000000Z',
+            'execution': {
+                'resolvers': [
+                    {
+                        'duration': 0,
+                        'fieldName': 'status',
+                        'parentType': 'Query',
+                        'path': [
+                            'status'
+                        ],
+                        'returnType': 'Boolean',
+                        'startOffset': 0
+                    }
+                ]
+            },
+            'startTime': '2012-01-14T03:21:34.000000Z',
+            'version': 1
+        }
+    }
+}
+
+snapshots['test_apollotracing_extension_handles_exceptions_in_resolvers 1'] = {
+    'testError': None
+}


### PR DESCRIPTION
This PR is accumulation of few small extensions cleanups:

- Commited snapshot for sync apollo tracing extension test (cleanup after #239).
- Removed `error` from `request_finished` hook (fixes #242).
- Added tests checking if noop extensions hooks implemented in base classes don't interrupt query execution  (discussed in #239).