### PR TITLE
Iterate over copy of the map in case directives need to add types

### DIFF
--- a/ariadne/schema_visitor.py
+++ b/ariadne/schema_visitor.py
@@ -72,7 +72,7 @@ def update_each_key(object_map: VisitableMap, callback: Callback):
 
     keys_to_remove: List[str] = []
 
-    for key, value in object_map.items():
+    for key, value in object_map.copy().items():
         result = callback(value, key)
         if result is False:
             keys_to_remove.append(key)

--- a/tests/test_directives.py
+++ b/tests/test_directives.py
@@ -510,7 +510,7 @@ def test_can_be_used_to_implement_auth_example():
     )
 
 
-def test_directive_can_add_new_type():
+def test_directive_can_add_new_type_to_schema():
     type_defs = """
         directive @key on OBJECT
 


### PR DESCRIPTION
This might be handy and make it easier to implement some directives like `@key` that needs to create a `_Entity` union type etc.