### PR TITLE
Pass request context to manager instance, and from there to hooks

### DIFF
--- a/ariadne/contrib/tracing/apollotracing.py
+++ b/ariadne/contrib/tracing/apollotracing.py
@@ -74,7 +74,7 @@ class ApolloTracingExtension(Extension):
             "resolvers": self.resolvers,
         }
 
-    def format(self):
+    def format(self, context: ContextValue):
         totals = self.get_totals()
 
         return {

--- a/ariadne/extensions.py
+++ b/ariadne/extensions.py
@@ -47,7 +47,7 @@ class ExtensionManager:
     def format(self) -> dict:
         data = {}
         for ext in self.extensions:
-            ext_data = ext.format()
+            ext_data = ext.format(self.context)
             if ext_data:
                 data.update(ext_data)
         return data

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -43,9 +43,9 @@ async def graphql(
     extensions: Optional[List[Type[Extension]]] = None,
     **kwargs,
 ) -> GraphQLResult:
-    extension_manager = ExtensionManager(extensions)
+    extension_manager = ExtensionManager(extensions, context_value)
 
-    with extension_manager.request(context_value):
+    with extension_manager.request():
         try:
             validate_data(data)
             query, variables, operation_name = (
@@ -117,9 +117,9 @@ def graphql_sync(
     extensions: Optional[List[Type[Extension]]] = None,
     **kwargs,
 ) -> GraphQLResult:
-    extension_manager = ExtensionManager(extensions)
+    extension_manager = ExtensionManager(extensions, context_value)
 
-    with extension_manager.request(context_value):
+    with extension_manager.request():
         try:
             validate_data(data)
             query, variables, operation_name = (

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -40,7 +40,7 @@ class Extension(Protocol):
             result = await result
         return result
 
-    def has_errors(self, errors: List[GraphQLError]):
+    def has_errors(self, errors: List[GraphQLError], context: ContextValue):
         pass  # pragma: no cover
 
     def format(self) -> dict:

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -43,8 +43,8 @@ class Extension(Protocol):
     def has_errors(self, errors: List[GraphQLError], context: ContextValue):
         pass  # pragma: no cover
 
-    def format(self) -> dict:
-        return {}  # pragma: no cover
+    def format(self, context: ContextValue) -> Optional[dict]:
+        pass  # pragma: no cover
 
 
 class ExtensionSync(Extension):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -10,7 +10,7 @@ context = {}
 exception = ValueError()
 
 
-def test_request_started_event_is_called_by_extension_manager():
+def test_request_started_hook_is_called_by_extension_manager():
     extension = Mock(spec=Extension)
     manager = ExtensionManager([Mock(return_value=extension)], context)
     with manager.request():
@@ -19,7 +19,7 @@ def test_request_started_event_is_called_by_extension_manager():
     extension.request_started.assert_called_once_with(context)
 
 
-def test_request_finished_event_is_called_by_extension_manager():
+def test_request_finished_hook_is_called_by_extension_manager():
     extension = Mock(spec=Extension)
     manager = ExtensionManager([Mock(return_value=extension)], context)
     with manager.request():
@@ -28,14 +28,14 @@ def test_request_finished_event_is_called_by_extension_manager():
     extension.request_finished.assert_called_once_with(context)
 
 
-def test_has_errors_event_is_called_with_errors_list_and_context():
+def test_has_errors_hook_is_called_with_errors_list_and_context():
     extension = Mock(spec=Extension)
     manager = ExtensionManager([Mock(return_value=extension)], context)
     manager.has_errors([exception])
     extension.has_errors.assert_called_once_with([exception], context)
 
 
-def test_extension_format_is_called_with_context():
+def test_extension_format_hook_is_called_with_context():
     extension = Mock(spec=Extension, format=Mock(return_value={"a": 1}))
     manager = ExtensionManager([Mock(return_value=extension)], context)
     manager.format()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -35,6 +35,13 @@ def test_has_errors_event_is_called_with_errors_list_and_context():
     extension.has_errors.assert_called_once_with([exception], context)
 
 
+def test_extension_format_is_called_with_context():
+    extension = Mock(spec=Extension, format=Mock(return_value={"a": 1}))
+    manager = ExtensionManager([Mock(return_value=extension)], context)
+    manager.format()
+    extension.format.assert_called_once_with(context)
+
+
 def test_extensions_are_formatted():
     extensions = [
         Mock(spec=Extension, format=Mock(return_value={"a": 1})),

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -12,8 +12,8 @@ exception = ValueError()
 
 def test_request_started_event_is_called_by_extension_manager():
     extension = Mock(spec=Extension)
-    manager = ExtensionManager([Mock(return_value=extension)])
-    with manager.request(context):
+    manager = ExtensionManager([Mock(return_value=extension)], context)
+    with manager.request():
         pass
 
     extension.request_started.assert_called_once_with(context)
@@ -21,18 +21,18 @@ def test_request_started_event_is_called_by_extension_manager():
 
 def test_request_finished_event_is_called_by_extension_manager():
     extension = Mock(spec=Extension)
-    manager = ExtensionManager([Mock(return_value=extension)])
-    with manager.request(context):
+    manager = ExtensionManager([Mock(return_value=extension)], context)
+    with manager.request():
         pass
 
     extension.request_finished.assert_called_once_with(context)
 
 
-def test_has_errors_event_is_called_with_errors_list():
+def test_has_errors_event_is_called_with_errors_list_and_context():
     extension = Mock(spec=Extension)
-    manager = ExtensionManager([Mock(return_value=extension)])
+    manager = ExtensionManager([Mock(return_value=extension)], context)
     manager.has_errors([exception])
-    extension.has_errors.assert_called_once_with([exception])
+    extension.has_errors.assert_called_once_with([exception], context)
 
 
 def test_extensions_are_formatted():

--- a/tests/test_extensions_sync.py
+++ b/tests/test_extensions_sync.py
@@ -8,7 +8,7 @@ context = {}
 exception = ValueError()
 
 
-def test_request_started_event_is_called_by_extension_manager():
+def test_request_started_hook_is_called_by_extension_manager():
     extension = Mock(spec=ExtensionSync)
     manager = ExtensionManager([Mock(return_value=extension)], context)
     with manager.request():
@@ -17,7 +17,7 @@ def test_request_started_event_is_called_by_extension_manager():
     extension.request_started.assert_called_once_with(context)
 
 
-def test_request_finished_event_is_called_by_extension_manager():
+def test_request_finished_hook_is_called_by_extension_manager():
     extension = Mock(spec=ExtensionSync)
     manager = ExtensionManager([Mock(return_value=extension)], context)
     with manager.request():
@@ -26,14 +26,14 @@ def test_request_finished_event_is_called_by_extension_manager():
     extension.request_finished.assert_called_once_with(context)
 
 
-def test_has_errors_event_is_called_with_errors_list_and_context():
+def test_has_errors_hook_is_called_with_errors_list_and_context():
     extension = Mock(spec=ExtensionSync)
     manager = ExtensionManager([Mock(return_value=extension)], context)
     manager.has_errors([exception])
     extension.has_errors.assert_called_once_with([exception], context)
 
 
-def test_extension_format_is_called_with_context():
+def test_extension_format_hook_is_called_with_context():
     extension = Mock(spec=ExtensionSync, format=Mock(return_value={"a": 1}))
     manager = ExtensionManager([Mock(return_value=extension)], context)
     manager.format()

--- a/tests/test_extensions_sync.py
+++ b/tests/test_extensions_sync.py
@@ -4,14 +4,14 @@ from ariadne import ExtensionManager, graphql_sync
 from ariadne.types import ExtensionSync
 
 
-context: dict = {}
+context = {}
 exception = ValueError()
 
 
 def test_request_started_event_is_called_by_extension_manager():
     extension = Mock(spec=ExtensionSync)
-    manager = ExtensionManager([Mock(return_value=extension)])
-    with manager.request(context):
+    manager = ExtensionManager([Mock(return_value=extension)], context)
+    with manager.request():
         pass
 
     extension.request_started.assert_called_once_with(context)
@@ -19,18 +19,18 @@ def test_request_started_event_is_called_by_extension_manager():
 
 def test_request_finished_event_is_called_by_extension_manager():
     extension = Mock(spec=ExtensionSync)
-    manager = ExtensionManager([Mock(return_value=extension)])
-    with manager.request(context):
+    manager = ExtensionManager([Mock(return_value=extension)], context)
+    with manager.request():
         pass
 
     extension.request_finished.assert_called_once_with(context)
 
 
-def test_has_errors_event_is_called_with_errors_list():
+def test_has_errors_event_is_called_with_errors_list_and_context():
     extension = Mock(spec=ExtensionSync)
-    manager = ExtensionManager([Mock(return_value=extension)])
+    manager = ExtensionManager([Mock(return_value=extension)], context)
     manager.has_errors([exception])
-    extension.has_errors.assert_called_once_with([exception])
+    extension.has_errors.assert_called_once_with([exception], context)
 
 
 def test_extensions_are_formatted():
@@ -38,7 +38,7 @@ def test_extensions_are_formatted():
         Mock(spec=ExtensionSync, format=Mock(return_value={"a": 1})),
         Mock(spec=ExtensionSync, format=Mock(return_value={"b": 2})),
     ]
-    manager = ExtensionManager([Mock(return_value=ext) for ext in extensions])
+    manager = ExtensionManager([Mock(return_value=ext) for ext in extensions], context)
     assert manager.format() == {"a": 1, "b": 2}
 
 

--- a/tests/test_extensions_sync.py
+++ b/tests/test_extensions_sync.py
@@ -33,6 +33,13 @@ def test_has_errors_event_is_called_with_errors_list_and_context():
     extension.has_errors.assert_called_once_with([exception], context)
 
 
+def test_extension_format_is_called_with_context():
+    extension = Mock(spec=ExtensionSync, format=Mock(return_value={"a": 1}))
+    manager = ExtensionManager([Mock(return_value=extension)], context)
+    manager.format()
+    extension.format.assert_called_once_with(context)
+
+
 def test_extensions_are_formatted():
     extensions = [
         Mock(spec=ExtensionSync, format=Mock(return_value={"a": 1})),


### PR DESCRIPTION
This PR is an exploration for how we could improve how extension hooks are passed the context. I've changed `ExtensionManager` implementation so context is passed to it together with extensions list. This gives manager single point for obtaining context for the current request, simplifying its calls in `graphql()`, and letting us pass `context` to extensions `has_errors` hook in a clean way.

Considered that extensions themselves are instantiated for the duration of request, we could also remove it from hooks, and instead update extension API so they are initialized with context as only argument, eg:

```
class MyExtension(Extension):
    def __init__(self, context: ContextValue):
        self.context = context

    def has_errors(self, errors: List[GraphQLError]):
        report_errors_somewhere_using_errors_and_request(errors, self.context["request"])
```

...but I feel this will complicate creating partials and extension factories for minimal improvement in extension API - unless somebody would like to do context-specific initialization in their extension.

I also think that `format` hook could potentially profit from receiving context - somebody could implement custom extension for including extra info about query context specific to their app  during debugging...