### PR TITLE
Add schema validation to make_executable_schema

### DIFF
--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Type, Union
 from graphql import (
     DocumentNode,
     GraphQLSchema,
+    assert_valid_schema,
     build_ast_schema,
     extend_schema,
     parse,
@@ -37,6 +38,8 @@ def make_executable_schema(
 
     if directives:
         SchemaDirectiveVisitor.visit_schema_directives(schema, directives)
+
+    assert_valid_schema(schema)
 
     return schema
 

--- a/tests/test_executable_schema_validation.py
+++ b/tests/test_executable_schema_validation.py
@@ -1,0 +1,23 @@
+import pytest
+
+from ariadne import make_executable_schema
+
+
+def test_executable_schema_creation_errors_if_type_defs_is_graphql_query():
+    type_defs = """
+        query { test }
+    """
+
+    with pytest.raises(TypeError):
+        make_executable_schema(type_defs)
+
+
+def test_executable_schema_creation_errors_if_type_defs_is_invalid_schema():
+    type_defs = """
+        type Mutation {
+            test: Boolean!
+        }
+    """
+
+    with pytest.raises(TypeError):
+        make_executable_schema(type_defs)


### PR DESCRIPTION
Code and tests to add schema validation to `make_executable_schema`. Fixes issue #251 