### PR TITLE
Add `map_kwargs` utility decorator

### DIFF
--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -29,6 +29,7 @@ from .utils import (
     convert_camel_case_to_snake,
     convert_kwargs_to_snake_case,
     gql,
+    map_kwargs,
     unwrap_graphql_error,
 )
 
@@ -60,6 +61,7 @@ __all__ = [
     "is_default_resolver",
     "load_schema_from_path",
     "make_executable_schema",
+    "map_kwargs",
     "resolve_to",
     "snake_case_fallback_resolvers",
     "subscribe",

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -49,3 +49,36 @@ def convert_kwargs_to_snake_case(func: Callable) -> Callable:
         return func(*args, **convert_to_snake_case(kwargs))
 
     return wrapper
+
+
+def map_kwargs(mappings: Dict) -> Callable:
+    """
+	This decorator will map a schema argument name to a different
+	resolver parameter name. Useful for mapping `id` or `type`.
+	"""
+
+    def inner(func: Callable) -> Callable:
+        def do_mapping(kwargs: Dict) -> Dict:
+            mapped_kwargs = {}
+            for key, value in kwargs.items():
+                if key in mappings:
+                    mapped_kwargs[mappings[key]] = value
+                else:
+                    mapped_kwargs[key] = value
+            return mapped_kwargs
+
+        if asyncio.iscoroutinefunction(func):
+
+            @wraps(func)
+            async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+                return await func(*args, **do_mapping(kwargs))
+
+            return async_wrapper
+
+        @wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            return func(*args, **do_mapping(kwargs))
+
+        return wrapper
+
+    return inner

--- a/tests/test_map_kwargs.py
+++ b/tests/test_map_kwargs.py
@@ -1,0 +1,53 @@
+import pytest
+
+from graphql import graphql, graphql_sync
+
+from ariadne import QueryType, make_executable_schema, map_kwargs
+
+
+type_defs = """
+    type Query {
+        test(id: Int!, type: String, name: String): Boolean
+    }
+"""
+
+
+def test_decorator_map_kwargs_sync():
+    query = QueryType()
+
+    @query.field("test")
+    @map_kwargs({"id": "id_", "type": "user_type"})
+    def resolve_test(*_, id_, user_type, name=None):  # pylint: disable=unused-variable
+        assert id_ == 42
+        assert user_type == "test"
+        assert name == "untouched"
+
+        return True
+
+    schema = make_executable_schema(type_defs, query)
+
+    result = graphql_sync(schema, '{ test(id: 42, type: "test", name: "untouched") }')
+    assert result.errors is None
+    assert result.data == {"test": True}
+
+
+@pytest.mark.asyncio
+async def test_decorator_map_kwargs_async():
+    query = QueryType()
+
+    @query.field("test")
+    @map_kwargs({"id": "id_", "type": "user_type"})
+    async def resolve_test(
+        *_, id_, user_type, name=None
+    ):  # pylint: disable=unused-variable
+        assert id_ == 42
+        assert user_type == "test"
+        assert name == "untouched"
+
+        return True
+
+    schema = make_executable_schema(type_defs, query)
+
+    result = await graphql(schema, '{ test(id: 42, type: "test", name: "untouched") }')
+    assert result.errors is None
+    assert result.data == {"test": True}


### PR DESCRIPTION
This decorator allows the schema to use Python build-in keywords, such as `id` and `type`, but maps the resolver kwargs to a non-conflicting parameter name, such as `id_` or `user_type`.