### PR TITLE
Recursively load schema from path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.8.0 (UNRELEASED)
+
+- Added recursive loading of GraphQL schema files from provided path.
+
+
 ## 0.7.0 (2019-10-03)
 
 - Added support for custom schema directives.

--- a/ariadne/load_schema.py
+++ b/ariadne/load_schema.py
@@ -9,16 +9,17 @@ from .exceptions import GraphQLFileSyntaxError
 
 def load_schema_from_path(path: str) -> str:
     if os.path.isdir(path):
-        schema_list = [read_graphql_file(f) for f in walk_graphql_files(path)]
+        schema_list = [read_graphql_file(f) for f in sorted(walk_graphql_files(path))]
         return "\n".join(schema_list)
     return read_graphql_file(os.path.abspath(path))
 
 
-def walk_graphql_files(path: str) -> Generator:
-    def abs_path(f):
-        return os.path.abspath(os.path.join(path, f))
-
-    return (abs_path(f) for f in sorted(os.listdir(path)) if f.endswith(".graphql"))
+def walk_graphql_files(path: str) -> Generator[str, None, None]:
+    extension = ".graphql"
+    for dirpath, _, files in os.walk(path):
+        for name in files:
+            if extension and name.lower().endswith(extension):
+                yield os.path.join(dirpath, name)
 
 
 def read_graphql_file(path: str) -> str:

--- a/tests/test_schema_file_load.py
+++ b/tests/test_schema_file_load.py
@@ -1,4 +1,7 @@
+import pathlib
+
 import pytest
+
 from ariadne import exceptions, load_schema_from_path
 
 FIRST_SCHEMA = """
@@ -67,5 +70,23 @@ def schema_directory(tmpdir_factory):
 
 def test_loading_schema_from_directory(schema_directory):
     assert load_schema_from_path(str(schema_directory)) == "\n".join(
+        [FIRST_SCHEMA, SECOND_SCHEMA]
+    )
+
+
+@pytest.fixture
+def schema_nested_directories(tmp_path_factory):
+    directory = tmp_path_factory.mktemp("schema")
+    nested_dir = pathlib.Path(directory.resolve(), "nested")
+    nested_dir.mkdir()
+    first_file = pathlib.Path(directory.resolve(), "base.graphql")
+    first_file.write_text(FIRST_SCHEMA)
+    second_file = pathlib.Path(nested_dir.resolve(), "user.graphql")
+    second_file.write_text(SECOND_SCHEMA)
+    return directory
+
+
+def test_loading_schema_from_nested_directories(schema_nested_directories):
+    assert load_schema_from_path(str(schema_nested_directories)) == "\n".join(
         [FIRST_SCHEMA, SECOND_SCHEMA]
     )


### PR DESCRIPTION
Now, when providing path to load multiple schema files, we traverse the tree in search of _.graphql_ files.