### PR TITLE
Allow the default_literal_parser to accept arguments to be passed into it.

### DIFF
--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -86,7 +86,7 @@ SCALAR_AST_NODES = (BooleanValueNode, FloatValueNode, IntValueNode, StringValueN
 def create_default_literal_parser(
     value_parser: GraphQLScalarValueParser,
 ) -> GraphQLScalarLiteralParser:
-    def default_literal_parser(ast, _arguments):
+    def default_literal_parser(ast, _arguments=None):
         return value_parser(ast.value)
 
     return default_literal_parser

--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -86,7 +86,8 @@ SCALAR_AST_NODES = (BooleanValueNode, FloatValueNode, IntValueNode, StringValueN
 def create_default_literal_parser(
     value_parser: GraphQLScalarValueParser,
 ) -> GraphQLScalarLiteralParser:
-    def default_literal_parser(ast):
+    def default_literal_parser(ast, *args, **kwargs):
+        print(args, kwargs)
         return value_parser(ast.value)
 
     return default_literal_parser

--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -86,8 +86,7 @@ SCALAR_AST_NODES = (BooleanValueNode, FloatValueNode, IntValueNode, StringValueN
 def create_default_literal_parser(
     value_parser: GraphQLScalarValueParser,
 ) -> GraphQLScalarLiteralParser:
-    def default_literal_parser(ast, *args, **kwargs):
-        print(args, kwargs)
+    def default_literal_parser(ast, _arguments):
         return value_parser(ast.value)
 
     return default_literal_parser


### PR DESCRIPTION
I came across this when trying to add filters to one of the fields in my schema.

eg.
```
query($userId: ID!) {
  user(id: $userId) {
    game(
      filter: {
        start: {
          gt: "2019-10-28T11:29:39.803866-07:53"
          lt: "2019-10-29T11:29:39.803866-07:53"
        }
      }
    ) {
      start
      end
    }
  }
}
```

This was throwing the error message: 
`graphql.error.graphql_error.GraphQLError: Argument 'filter' has invalid value {start: {gt: "2019-10-29T11:29:39.803866-07:53"}}.`

Digging into the graphql library code (chucking in some print statements) revealed the default_literal_parser to be the cause with not enough arguments being specified.

I suspect that the extra arguments ought to be passed on to the `value_parser` function but I am not familiar with the internals of Ariadne yet!

Let me know what else needs to be added (I assume at least a regression test?)