### PR TITLE
Allow queries on the same channel.

### DIFF
--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -310,7 +310,7 @@ def validate_query(
     return validate(schema, document_ast, rules=specified_rules, type_info=type_info)
 
 
-def validate_data(data: dict) -> None:
+def validate_data(data: Optional[dict]) -> None:
     if not isinstance(data, dict):
         raise GraphQLError("Operation data should be a JSON object")
     validate_query_body(data.get("query"))

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -33,10 +33,7 @@ def test_ping(client):
             {
                 "type": GQL_START,
                 "id": "test2",
-                "payload": {
-                    "operationName": None,
-                    "query": "{ testRoot }",
-                },
+                "payload": {"operationName": None, "query": "{ testRoot }",},
             }
         )
         response = ws.receive_json()

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -9,7 +9,7 @@ from ariadne.asgi import (
 )
 
 
-def test_ping(client):
+def test_ping_can_be_subscribed_using_websocket_connection(client):
     with client.websocket_connect("/", "graphql-ws") as ws:
         ws.send_json({"type": GQL_CONNECTION_INIT})
         ws.send_json(
@@ -29,6 +29,14 @@ def test_ping(client):
         response = ws.receive_json()
         assert response["type"] == GQL_COMPLETE
         assert response["id"] == "test1"
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+
+def test_query_can_be_executed_using_websocket_connection(client):
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
         ws.send_json(
             {
                 "type": GQL_START,

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -29,6 +29,20 @@ def test_ping(client):
         response = ws.receive_json()
         assert response["type"] == GQL_COMPLETE
         assert response["id"] == "test1"
+        ws.send_json(
+            {
+                "type": GQL_START,
+                "id": "test2",
+                "payload": {
+                    "operationName": None,
+                    "query": "{ testRoot }",
+                },
+            }
+        )
+        response = ws.receive_json()
+        assert response["type"] == GQL_DATA
+        assert response["id"] == "test2"
+        assert response["payload"]["data"] == {"testRoot": None}
         ws.send_json({"type": GQL_CONNECTION_TERMINATE})
 
 


### PR DESCRIPTION
When creating a WS connection with Apollo as a JS client, it's possible to also send queries on the same channel, not only subscription requests. This PR implements that on the server-side.