### PR TITLE
Initial groundwork for editable / disabling graphql playground

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -1,7 +1,6 @@
 import asyncio
 import json
 from inspect import isawaitable
-from enum import Enum, auto
 from typing import (
     Any,
     AsyncGenerator,
@@ -22,8 +21,7 @@ from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, R
 from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketState, WebSocketDisconnect
 
-from .constants import DATA_TYPE_JSON, DATA_TYPE_MULTIPART, PLAYGROUND_HTML, CONTENT_TYPE_JSON, CONTENT_TYPE_GRAPHQL, \
-    CONTENT_TYPE_TEXT_HTML, CONTENT_TYPE_TEXT_PLAIN
+from .constants import DATA_TYPE_JSON, DATA_TYPE_MULTIPART, PLAYGROUND_HTML
 from .playground import generate_playground_options, PlaygroundSettings
 from .exceptions import HttpBadRequestError, HttpError
 from .file_uploads import combine_multipart_data
@@ -54,26 +52,6 @@ MiddlewareList = Optional[List[Middleware]]
 Middlewares = Union[
     Callable[[Any, Optional[ContextValue]], MiddlewareList], MiddlewareList
 ]
-
-
-class SupportedContentTypes(Enum):
-    JSON = CONTENT_TYPE_JSON
-    GRAPHQL = CONTENT_TYPE_GRAPHQL
-    HTML = CONTENT_TYPE_TEXT_HTML
-    PLAIN = CONTENT_TYPE_TEXT_PLAIN
-    NONE = None
-
-    @classmethod
-    def supported(cls, content_type):
-        return len({member.value.find(content_type) for _, member in cls.__members__.items()} & {0}) > 0
-
-    @classmethod
-    def factory(cls, content_type):
-        if content_type is None:
-            return SupportedContentTypes.NONE
-        for _, member in cls.__members__.items():
-            if member.value.find(content_type) == 0:
-                return member
 
 
 class GraphQL:
@@ -146,7 +124,6 @@ class GraphQL:
 
     async def handle_http(self, scope: Scope, receive: Receive, send: Send):
         request = Request(scope=scope, receive=receive)
-        content_type: SupportedContentTypes = SupportedContentTypes.factory(request.headers.get("content-type"))
         user_agent: str = request.headers.get("user-agent")
         # https://graphql.org/learn/serving-over-http/#get-request
         if request.method == "GET":

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -56,19 +56,19 @@ Middlewares = Union[
 
 class GraphQL:
     def __init__(
-            self,
-            schema: GraphQLSchema,
-            *,
-            context_value: Optional[ContextValue] = None,
-            root_value: Optional[RootValue] = None,
-            debug: bool = False,
-            enable_playground: bool = True,
-            playground_settings: Optional[PlaygroundSettings] = None,
-            logger: Optional[str] = None,
-            error_formatter: ErrorFormatter = format_error,
-            extensions: Optional[Extensions] = None,
-            middleware: Optional[Middlewares] = None,
-            keepalive: float = None,
+        self,
+        schema: GraphQLSchema,
+        *,
+        context_value: Optional[ContextValue] = None,
+        root_value: Optional[RootValue] = None,
+        debug: bool = False,
+        enable_playground: bool = True,
+        playground_settings: Optional[PlaygroundSettings] = None,
+        logger: Optional[str] = None,
+        error_formatter: ErrorFormatter = format_error,
+        extensions: Optional[Extensions] = None,
+        middleware: Optional[Middlewares] = None,
+        keepalive: float = None,
     ):
         self.context_value = context_value
         self.root_value = root_value
@@ -100,7 +100,7 @@ class GraphQL:
         return self.context_value or {"request": request}
 
     async def get_extensions_for_request(
-            self, request: Any, context: Optional[ContextValue]
+        self, request: Any, context: Optional[ContextValue]
     ) -> ExtensionList:
         if callable(self.extensions):
             extensions = self.extensions(request, context)
@@ -110,7 +110,7 @@ class GraphQL:
         return self.extensions
 
     async def get_middleware_for_request(
-            self, request: Any, context: Optional[ContextValue]
+        self, request: Any, context: Optional[ContextValue]
     ) -> Optional[MiddlewareManager]:
         middleware = self.middleware
         if callable(middleware):
@@ -144,7 +144,7 @@ class GraphQL:
         await self.websocket_server(websocket)
 
     async def render_playground(  # pylint: disable=unused-argument
-            self, request: Request
+        self, request: Request
     ) -> Response:
         _settings = generate_playground_options(self.playground_settings) if self.playground_settings \
                                                                              is not None else ""
@@ -228,8 +228,8 @@ class GraphQL:
         await websocket.accept("graphql-ws")
         try:
             while (
-                    websocket.client_state != WebSocketState.DISCONNECTED
-                    and websocket.application_state != WebSocketState.DISCONNECTED
+                websocket.client_state != WebSocketState.DISCONNECTED
+                and websocket.application_state != WebSocketState.DISCONNECTED
             ):
                 message = await websocket.receive_json()
                 await self.handle_websocket_message(message, websocket, subscriptions)
@@ -240,10 +240,10 @@ class GraphQL:
                 await subscriptions[operation_id].aclose()
 
     async def handle_websocket_message(
-            self,
-            message: dict,
-            websocket: WebSocket,
-            subscriptions: Dict[str, AsyncGenerator],
+        self,
+        message: dict,
+        websocket: WebSocket,
+        subscriptions: Dict[str, AsyncGenerator],
     ):
         operation_id = cast(str, message.get("id"))
         message_type = cast(str, message.get("type"))
@@ -273,11 +273,11 @@ class GraphQL:
             await asyncio.sleep(self.keepalive)
 
     async def start_websocket_subscription(
-            self,
-            data: Any,
-            operation_id: str,
-            websocket: WebSocket,
-            subscriptions: Dict[str, AsyncGenerator],
+        self,
+        data: Any,
+        operation_id: str,
+        websocket: WebSocket,
+        subscriptions: Dict[str, AsyncGenerator],
     ):
         context_value = await self.get_context_for_request(websocket)
         success, results = await subscribe(
@@ -329,7 +329,7 @@ class GraphQL:
             )
 
         if (
-                websocket.client_state != WebSocketState.DISCONNECTED
-                and websocket.application_state != WebSocketState.DISCONNECTED
+            websocket.client_state != WebSocketState.DISCONNECTED
+            and websocket.application_state != WebSocketState.DISCONNECTED
         ):
             await websocket.send_json({"type": GQL_COMPLETE, "id": operation_id})

--- a/ariadne/constants.py
+++ b/ariadne/constants.py
@@ -4,7 +4,6 @@ DATA_TYPE_MULTIPART = "multipart/form-data"
 CONTENT_TYPE_JSON = "application/json; charset=UTF-8"
 CONTENT_TYPE_TEXT_HTML = "text/html; charset=UTF-8"
 CONTENT_TYPE_TEXT_PLAIN = "text/plain; charset=UTF-8"
-CONTENT_TYPE_GRAPHQL = "application/graphql; charset=UTF-8"
 
 HTTP_STATUS_200_OK = "200 OK"
 HTTP_STATUS_400_BAD_REQUEST = "400 Bad Request"

--- a/ariadne/constants.py
+++ b/ariadne/constants.py
@@ -4,6 +4,7 @@ DATA_TYPE_MULTIPART = "multipart/form-data"
 CONTENT_TYPE_JSON = "application/json; charset=UTF-8"
 CONTENT_TYPE_TEXT_HTML = "text/html; charset=UTF-8"
 CONTENT_TYPE_TEXT_PLAIN = "text/plain; charset=UTF-8"
+CONTENT_TYPE_GRAPHQL = "application/graphql; charset=UTF-8"
 
 HTTP_STATUS_200_OK = "200 OK"
 HTTP_STATUS_400_BAD_REQUEST = "400 Bad Request"
@@ -25,42 +26,43 @@ PLAYGROUND_HTML = """
 <body>
   <div id="root">
     <style>
-      body {
+      body {{
         background-color: rgb(23, 42, 58);
         font-family: Open Sans, sans-serif;
         height: 90vh;
-      }
-      #root {
+      }}
+      #root {{
         height: 100%;
         width: 100%;
         display: flex;
         align-items: center;
         justify-content: center;
-      }
-      .loading {
+      }}
+      .loading {{
         font-size: 32px;
         font-weight: 200;
         color: rgba(255, 255, 255, .6);
         margin-left: 20px;
-      }
-      img {
+      }}
+      img {{
         width: 78px;
         height: 78px;
-      }
-      .title {
+      }}
+      .title {{
         font-weight: 400;
-      }
+      }}
     </style>
     <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
     <div class="loading"> Loading
       <span class="title">GraphQL Playground</span>
     </div>
   </div>
-  <script>window.addEventListener('load', function (event) {
-      GraphQLPlayground.init(document.getElementById('root'), {
+  <script>window.addEventListener('load', function (event) {{
+      GraphQLPlayground.init(document.getElementById('root'), {{
         // options as 'endpoint' belong here
-      })
-    })</script>
+        {playground_options}
+      }})
+    }})</script>
 </body>
 
 </html>

--- a/ariadne/playground.py
+++ b/ariadne/playground.py
@@ -1,0 +1,81 @@
+from dataclasses import dataclass, asdict
+from enum import Enum
+import json
+from typing import Optional, Dict
+
+
+class RequestCredentials(Enum):
+    OMIT = "omit"
+    INCLUDE = "include"
+    SAME_ORIGIN = "same-origin"
+
+
+class EditorTheme(Enum):
+    LIGHT = "light"
+    DARK = "dark"
+
+
+class CursorShape(Enum):
+    LINE = "line"
+    BLOCK = "block"
+    UNDERLINE = "underline"
+
+
+@dataclass(frozen=True)
+class ISettings:
+    editor_cursor_shape: Optional[CursorShape] = None
+    editor_font_family: Optional[str] = None
+    editor_font_size: Optional[int] = None
+    editor_reuse_headers: Optional[bool] = None
+    editor_theme: EditorTheme = None
+    general_beta_updates: bool = None
+    prettier_print_width: int = None
+    prettier_tab_width: int = None
+    prettier_use_tabs: bool = None
+    request_credentials: RequestCredentials = None
+    schema_disable_comments: bool = None
+    schema_polling_enable: bool = None
+    schema_polling_endpoint_filter: str = None
+    schema_polling_interval: int = None
+    tracing_hide_tracing_response: bool = None
+
+    def to_json(self):
+        raw_dict = {
+            "editor.cursorShape": self.editor_cursor_shape,
+            "editor.fontFamily": self.editor_font_family,
+            "editor.fontSize": self.editor_font_size,
+            "editor.reuseHeaders": self.editor_reuse_headers,
+            "editor.theme": self.editor_theme.value if self.editor_theme is not None else None,
+            "general.betaUpdates": self.general_beta_updates,
+            "prettier.printWidth": self.prettier_print_width,
+            "prettier.tabWidth": self.prettier_tab_width,
+            "prettier.useTabs": self.prettier_use_tabs,
+            "request.credentials": self.request_credentials.value if self.request_credentials is not None else None,
+            "schema.disableComments": self.schema_disable_comments,
+            "schema.polling.enable": self.schema_polling_enable,
+            "schema.polling.endpointFilter": self.schema_polling_endpoint_filter,
+            "schema.polling.interval": self.schema_polling_interval,
+            "tracing.hideTracingResponse": self.tracing_hide_tracing_response
+        }
+        return {k: v for k, v in raw_dict.items() if v is not None}
+
+
+@dataclass(frozen=True)
+class PlaygroundSettings:
+    settings: Optional[ISettings] = None
+    share_enabled: Optional[str] = None
+    workpace_name: Optional[str] = None
+    headers: Optional[Dict[str, str]] = None
+
+
+def generate_playground_options(settings: PlaygroundSettings = None):
+    raw_dict = {
+        "settings": settings.settings.to_json(),
+        "shareEnabled": settings.share_enabled,
+        "workspaceName": settings.workpace_name,
+        "headers": settings.headers,
+    }
+    _dict = {k: v for k, v in raw_dict.items() if v is not None}
+    return ",\n".join([
+        f"{k}: {json.dumps(v)}" for k,v in _dict.items()
+    ])

--- a/ariadne/playground.py
+++ b/ariadne/playground.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from enum import Enum
 import json
 from typing import Optional, Dict

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "graphql-core>=3.0.0",
         "starlette<0.14",
         "typing_extensions>=3.6.0",
+        "dataclasses>=0.6;python_version<'3.7'"
     ],
     extras_require={"asgi-file-uploads": ["python-multipart>=0.0.5"]},
     classifiers=CLASSIFIERS,


### PR DESCRIPTION
Please see initial work for making the playground editable / ability to disable

1) I didn't think about supporting python3.6 (could add variable dataclass backport for 3.6)
2) I don't really know how to use pytest / snapshots and would love some pointers, but I'll try and get tests in
3) Is there a formatting / linting guide?

I initially wanted to try and implement the handling of different `content-type` headers, but I'll move that into a seperate PR.