### PR TITLE
fix setup.py for UnicodeDecodeError in cp1252.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ CLASSIFIERS = [
 ]
 
 README_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "README.md")
-with open(README_PATH, "r") as f:
+with open(README_PATH, "r", encoding="utf8") as f:
     README = f.read()
 
 setup(


### PR DESCRIPTION
When installing using 'pip install -e .' in a venv for python 3.8.2 on a windows 10 machine, saw an error which the last few lines read: 

    File "setup.py", line 19, in <module>
      README = f.read()
    File "C:\python3\lib\encodings\cp1252.py", line 23, in decode
      return codecs.charmap_decode(input,self.errors,decoding_table)[0]
    UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 4913: character maps to <undefined>

Fix suggested by https://stackoverflow.com/questions/49640513/unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d-in-position-x-charac

Installation succeeded with this fix. 