### PR TITLE
Adds snake_caseing to complex values inside lists

### DIFF
--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -33,6 +33,8 @@ def convert_kwargs_to_snake_case(func: Callable) -> Callable:
         for k, v in d.items():
             if isinstance(v, dict):
                 v = convert_to_snake_case(v)
+            if isinstance(v, list):
+                v = [convert_to_snake_case(i) for i in v]
             converted[convert_camel_case_to_snake(k)] = v
         return converted
 

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -34,7 +34,7 @@ def convert_kwargs_to_snake_case(func: Callable) -> Callable:
             if isinstance(v, dict):
                 v = convert_to_snake_case(v)
             if isinstance(v, list):
-                v = [convert_to_snake_case(i) for i in v]
+                v = [convert_to_snake_case(i) if isinstance(i, dict) else i for i in v]
             converted[convert_camel_case_to_snake(k)] = v
         return converted
 

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -48,6 +48,19 @@ def test_decorator_converts_objects_in_lists_to_camel_case():
     )
 
 
+def test_decorator_leaves_primitives_in_lists_unchanged():
+    @convert_kwargs_to_snake_case
+    def my_func(*_, **kwargs):
+        assert kwargs == {
+            "first_parameter": True,
+            "list_of_items": ["firstItem", "secondItem"],
+        }
+
+    my_func(
+        firstParameter=True, listOfItems=["firstItem", "secondItem"],
+    )
+
+
 @pytest.mark.asyncio
 async def test_decorator_converts_kwargs_to_camel_case_for_async_resolver():
     @convert_kwargs_to_snake_case

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -40,14 +40,11 @@ def test_decorator_converts_objects_in_lists_to_camel_case():
     def my_func(*_, **kwargs):
         assert kwargs == {
             "first_parameter": True,
-			"list_of_items": [
-				{"first_property": 1, "second_property": 2},
-			],
+            "list_of_items": [{"first_property": 1, "second_property": 2},],
         }
 
     my_func(
-        firstParameter=True,
-        listOfItems=[{"firstProperty": 1, "secondProperty": 2}],
+        firstParameter=True, listOfItems=[{"firstProperty": 1, "secondProperty": 2}],
     )
 
 

--- a/tests/test_kwargs_camel_case_conversion.py
+++ b/tests/test_kwargs_camel_case_conversion.py
@@ -35,6 +35,22 @@ def test_decorator_leaves_snake_case_kwargs_unchanged():
     )
 
 
+def test_decorator_converts_objects_in_lists_to_camel_case():
+    @convert_kwargs_to_snake_case
+    def my_func(*_, **kwargs):
+        assert kwargs == {
+            "first_parameter": True,
+			"list_of_items": [
+				{"first_property": 1, "second_property": 2},
+			],
+        }
+
+    my_func(
+        firstParameter=True,
+        listOfItems=[{"firstProperty": 1, "secondProperty": 2}],
+    )
+
+
 @pytest.mark.asyncio
 async def test_decorator_converts_kwargs_to_camel_case_for_async_resolver():
     @convert_kwargs_to_snake_case


### PR DESCRIPTION
The default decorator doesn't support converting values found inside lists to snake case. This leads to some weird inconsistencies when dealing with lists of custom object types. This change ensures that the snake-casing is applied to all levels of the object tree.

Example
--------

```
input Organization {
    orgName
}

input Project {
    parentOrgs: [Organization]
}

@mutation.field('createProject')
@convert_kwargs_to_snake_case
def create_project(_, info, project):
    print(project['parent_orgs'][0]['org_name'])

```