### PR TITLE
Roll-back #288: remove query/mutation execution over the websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.11.0 (UNRELEASED)
+
+- Removed support for sending queries and mutations via WebSocket.
+
+
 ## 0.10.0 (2020-02-11)
 
 - Added support for `Apollo Federation`.

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -25,9 +25,9 @@ from .constants import DATA_TYPE_JSON, DATA_TYPE_MULTIPART, PLAYGROUND_HTML
 from .exceptions import HttpBadRequestError, HttpError
 from .file_uploads import combine_multipart_data
 from .format_error import format_error
-from .graphql import graphql, subscribe, validate_data
+from .graphql import graphql, subscribe
 from .logger import log_error
-from .types import ContextValue, ErrorFormatter, Extension, GraphQLResult, RootValue
+from .types import ContextValue, ErrorFormatter, Extension, RootValue
 
 GQL_CONNECTION_INIT = "connection_init"  # Client -> Server
 GQL_CONNECTION_ACK = "connection_ack"  # Server -> Client
@@ -142,8 +142,21 @@ class GraphQL:
         except HttpError as error:
             return PlainTextResponse(error.message or error.status, status_code=400)
 
-        success, response = await self.execute_graphql_query(request, data)
+        context_value = await self.get_context_for_request(request)
+        extensions = await self.get_extensions_for_request(request, context_value)
+        middleware = await self.get_middleware_for_request(request, context_value)
 
+        success, response = await graphql(
+            self.schema,
+            data,
+            context_value=context_value,
+            root_value=self.root_value,
+            debug=self.debug,
+            logger=self.logger,
+            error_formatter=self.error_formatter,
+            extensions=extensions,
+            middleware=middleware,
+        )
         status_code = 200 if success else 400
         return JSONResponse(response, status_code=status_code)
 
@@ -226,7 +239,9 @@ class GraphQL:
         elif message_type == GQL_CONNECTION_TERMINATE:
             await websocket.close()
         elif message_type == GQL_START:
-            await self.process_single_message(websocket, subscriptions, message)
+            await self.start_websocket_subscription(
+                message.get("payload"), operation_id, websocket, subscriptions
+            )
         elif message_type == GQL_STOP:
             if operation_id in subscriptions:
                 await subscriptions[operation_id].aclose()
@@ -241,44 +256,6 @@ class GraphQL:
             except WebSocketDisconnect:
                 return
             await asyncio.sleep(self.keepalive)
-
-    async def process_single_message(
-        self,
-        websocket: WebSocket,
-        subscriptions: Dict[str, AsyncGenerator],
-        message: dict,
-    ) -> None:
-        operation_id = cast(str, message.get("id"))
-
-        payload = message.get("payload")
-        validate_data(payload)
-
-        if payload and "operationName" in payload and payload["operationName"] is None:
-            _, result = await self.execute_graphql_query(websocket, payload)
-            await websocket.send_json(
-                {"type": GQL_DATA, "id": operation_id, "payload": result}
-            )
-        else:
-            await self.start_websocket_subscription(
-                payload, operation_id, websocket, subscriptions
-            )
-
-    async def execute_graphql_query(self, request: Any, data: Any) -> GraphQLResult:
-        context_value = await self.get_context_for_request(request)
-        extensions = await self.get_extensions_for_request(request, context_value)
-        middleware = await self.get_middleware_for_request(request, context_value)
-
-        return await graphql(
-            self.schema,
-            data,
-            context_value=context_value,
-            root_value=self.root_value,
-            debug=self.debug,
-            logger=self.logger,
-            error_formatter=self.error_formatter,
-            extensions=extensions,
-            middleware=middleware,
-        )
 
     async def start_websocket_subscription(
         self,

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -9,7 +9,7 @@ from ariadne.asgi import (
 )
 
 
-def test_ping_can_be_subscribed_using_websocket_connection(client):
+def test_field_can_be_subscribed_using_websocket_connection(client):
     with client.websocket_connect("/", "graphql-ws") as ws:
         ws.send_json({"type": GQL_CONNECTION_INIT})
         ws.send_json(
@@ -17,6 +17,29 @@ def test_ping_can_be_subscribed_using_websocket_connection(client):
                 "type": GQL_START,
                 "id": "test1",
                 "payload": {"query": "subscription { ping }"},
+            }
+        )
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+        response = ws.receive_json()
+        assert response["type"] == GQL_DATA
+        assert response["id"] == "test1"
+        assert response["payload"]["data"] == {"ping": "pong"}
+        ws.send_json({"type": GQL_STOP, "id": "test1"})
+        response = ws.receive_json()
+        assert response["type"] == GQL_COMPLETE
+        assert response["id"] == "test1"
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+
+def test_field_can_be_subscribed_using_named_operation_in_websocket_connection(client):
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        ws.send_json(
+            {
+                "type": GQL_START,
+                "id": "test1",
+                "payload": {"query": "subscription PingTest { ping }"},
             }
         )
         response = ws.receive_json()

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -32,6 +32,32 @@ def test_field_can_be_subscribed_using_websocket_connection(client):
         ws.send_json({"type": GQL_CONNECTION_TERMINATE})
 
 
+def test_field_can_be_subscribed_using_unnamed_operation_in_websocket_connection(client):
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        ws.send_json(
+            {
+                "type": GQL_START,
+                "id": "test1",
+                "payload": {
+                    "operationName": None,
+                    "query": "subscription { ping }",
+                },
+            }
+        )
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+        response = ws.receive_json()
+        assert response["type"] == GQL_DATA
+        assert response["id"] == "test1"
+        assert response["payload"]["data"] == {"ping": "pong"}
+        ws.send_json({"type": GQL_STOP, "id": "test1"})
+        response = ws.receive_json()
+        assert response["type"] == GQL_COMPLETE
+        assert response["id"] == "test1"
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+
 def test_field_can_be_subscribed_using_named_operation_in_websocket_connection(client):
     with client.websocket_connect("/", "graphql-ws") as ws:
         ws.send_json({"type": GQL_CONNECTION_INIT})
@@ -39,7 +65,10 @@ def test_field_can_be_subscribed_using_named_operation_in_websocket_connection(c
             {
                 "type": GQL_START,
                 "id": "test1",
-                "payload": {"query": "subscription PingTest { ping }"},
+                "payload": {
+                    "operationName": "PingTest",
+                    "query": "subscription PingTest { ping }",
+                },
             }
         )
         response = ws.receive_json()

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -32,25 +32,6 @@ def test_ping_can_be_subscribed_using_websocket_connection(client):
         ws.send_json({"type": GQL_CONNECTION_TERMINATE})
 
 
-def test_query_can_be_executed_using_websocket_connection(client):
-    with client.websocket_connect("/", "graphql-ws") as ws:
-        ws.send_json({"type": GQL_CONNECTION_INIT})
-        response = ws.receive_json()
-        assert response["type"] == GQL_CONNECTION_ACK
-        ws.send_json(
-            {
-                "type": GQL_START,
-                "id": "test2",
-                "payload": {"operationName": None, "query": "{ testRoot }",},
-            }
-        )
-        response = ws.receive_json()
-        assert response["type"] == GQL_DATA
-        assert response["id"] == "test2"
-        assert response["payload"]["data"] == {"testRoot": None}
-        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
-
-
 def test_immediate_disconnect(client):
     with client.websocket_connect("/", "graphql-ws") as ws:
         ws.send_json({"type": GQL_CONNECTION_INIT})

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -32,17 +32,16 @@ def test_field_can_be_subscribed_using_websocket_connection(client):
         ws.send_json({"type": GQL_CONNECTION_TERMINATE})
 
 
-def test_field_can_be_subscribed_using_unnamed_operation_in_websocket_connection(client):
+def test_field_can_be_subscribed_using_unnamed_operation_in_websocket_connection(
+    client,
+):
     with client.websocket_connect("/", "graphql-ws") as ws:
         ws.send_json({"type": GQL_CONNECTION_INIT})
         ws.send_json(
             {
                 "type": GQL_START,
                 "id": "test1",
-                "payload": {
-                    "operationName": None,
-                    "query": "subscription { ping }",
-                },
+                "payload": {"operationName": None, "query": "subscription { ping }",},
             }
         )
         response = ws.receive_json()


### PR DESCRIPTION
This PR fixes #323 by rolling back changes from #288.

Also fixes #320