### PR TITLE
Freeze graphql-core dep at 3.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fixed `convert_kwargs_to_snake_case` utility so it also converts the case in lists items.
 - Removed support for sending queries and mutations via WebSocket.
+- Freezed `graphql-core` dependency at version 3.0.3.
 
 
 ## 0.10.0 (2020-02-11)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 #
 #    pip-compile --output-file=requirements.txt setup.py
 #
-graphql-core==3.0.0
+graphql-core==3.0.3
 starlette==0.13.2
 typing-extensions==3.7.4.1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     packages=["ariadne"],
     include_package_data=True,
     install_requires=[
-        "graphql-core>=3.0.0",
+        "graphql-core<3.1.0",
         "starlette<0.14",
         "typing_extensions>=3.6.0",
     ],


### PR DESCRIPTION
This is stop-gap fix for #345 

For 0.11 we should just freeze graphql-core to 3.0.3