### PR TITLE
Change default context in WSGI app to be dict with request key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fixed `convert_kwargs_to_snake_case` utility so it also converts the case in lists items.
 - Removed support for sending queries and mutations via WebSocket.
 - Freezed `graphql-core` dependency at version 3.0.3.
+- Unified default `info.context` value for WSGI to be dict with single `request` key.
 
 
 ## 0.10.0 (2020-02-11)

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -179,7 +179,7 @@ class GraphQL:
     def get_context_for_request(self, environ: dict) -> Optional[ContextValue]:
         if callable(self.context_value):
             return self.context_value(environ)
-        return self.context_value or environ
+        return self.context_value or {"request": environ}
 
     def get_extensions_for_request(
         self, environ: dict, context: Optional[ContextValue]


### PR DESCRIPTION
In our docs we keep using `info.context` as dict with `request` key , but in WSGI app we default to `environ`. This change replaced default context for WSGI app with `{"request": environ}` so it's shape follows what we are describing in docs.