### PR TITLE
Use graphql.utilities.value_from_ast_untyped to parse ast in default literal parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Added `validation_rules` option to query executors as well as ASGI and WSGI apps and Django view that allow developers to include custom query validation logic in their APIs.
 - Added `validation.cost_validator` query validator that allows developers to limit maximum allowed query cost/complexity.
+- `ScalarType` default literal parser now uses `graphql.utilities.value_from_ast_untyped` to parse the AST.
 
 
 ## 0.11.0 (2020-04-01)

--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -14,6 +14,7 @@ from graphql.type import (
     GraphQLScalarValueParser,
     GraphQLSchema,
 )
+from graphql.utilities import value_from_ast_untyped
 
 from .types import SchemaBindable
 
@@ -87,6 +88,6 @@ def create_default_literal_parser(
     value_parser: GraphQLScalarValueParser,
 ) -> GraphQLScalarLiteralParser:
     def default_literal_parser(ast):
-        return value_parser(ast.value)
+        return value_parser(value_from_ast_untyped(ast))
 
     return default_literal_parser

--- a/tests/test_custom_scalars.py
+++ b/tests/test_custom_scalars.py
@@ -250,13 +250,13 @@ def test_literal_string_is_deserialized_by_default_parser():
 def test_literal_int_is_deserialized_by_default_parser():
     result = graphql_sync(schema, "{ testInputValueType(value: 123) }")
     assert result.errors is None
-    assert result.data == {"testInputValueType": "str"}
+    assert result.data == {"testInputValueType": "int"}
 
 
 def test_literal_float_is_deserialized_by_default_parser():
     result = graphql_sync(schema, "{ testInputValueType(value: 1.5) }")
     assert result.errors is None
-    assert result.data == {"testInputValueType": "str"}
+    assert result.data == {"testInputValueType": "float"}
 
 
 def test_literal_bool_true_is_deserialized_by_default_parser():
@@ -269,3 +269,15 @@ def test_literal_bool_false_is_deserialized_by_default_parser():
     result = graphql_sync(schema, "{ testInputValueType(value: false) }")
     assert result.errors is None
     assert result.data == {"testInputValueType": "bool"}
+
+
+def test_literal_object_is_deserialized_by_default_parser():
+    result = graphql_sync(schema, "{ testInputValueType(value: {}) }")
+    assert result.errors is None
+    assert result.data == {"testInputValueType": "dict"}
+
+
+def test_literal_list_is_deserialized_by_default_parser():
+    result = graphql_sync(schema, "{ testInputValueType(value: []) }")
+    assert result.errors is None
+    assert result.data == {"testInputValueType": "list"}


### PR DESCRIPTION
The `default_literal_parser()` function in `ariadne.scalars` returns `ast.value`. However, in the case that `ast` is a node such as `ObjectValueNode` or `ListValueNode`, this causes an exception because these nodes do not have a value member.

Fixed by parsing `ast` with `graphql.utilities.value_from_ast_untyped`.

Fixes #356