### PR TITLE
Fix linting errors occuring on pylint 2.5

### DIFF
--- a/ariadne/contrib/tracing/apollotracing.py
+++ b/ariadne/contrib/tracing/apollotracing.py
@@ -89,7 +89,9 @@ class ApolloTracingExtension(Extension):
 
 
 class ApolloTracingExtensionSync(ApolloTracingExtension):
-    def resolve(self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs):
+    def resolve(
+        self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs
+    ):  # pylint: disable=invalid-overridden-method
         if not should_trace(info):
             result = next_(parent, info, **kwargs)
             return result

--- a/ariadne/contrib/tracing/opentracing.py
+++ b/ariadne/contrib/tracing/opentracing.py
@@ -69,7 +69,9 @@ class OpenTracingExtension(Extension):
 
 
 class OpenTracingExtensionSync(OpenTracingExtension):
-    def resolve(self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs):
+    def resolve(
+        self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs
+    ):  # pylint: disable=invalid-overridden-method
         if not should_trace(info):
             result = next_(parent, info, **kwargs)
             return result

--- a/ariadne/schema_visitor.py
+++ b/ariadne/schema_visitor.py
@@ -56,7 +56,7 @@ Callback = Callable[..., Any]
 
 
 def each(list_or_dict: IndexedObject, callback: Callback):
-    if isinstance(list_or_dict, List):
+    if isinstance(list_or_dict, list):
         for value in list_or_dict:
             callback(value)
     else:

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -66,7 +66,9 @@ class Extension(Protocol):
 
 
 class ExtensionSync(Extension):
-    def resolve(self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs):
+    def resolve(
+        self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs
+    ):  # pylint: disable=invalid-overridden-method
         return next_(parent, info, **kwargs)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@
 #    pip-compile --output-file=requirements-dev.txt requirements-dev.in
 #
 appdirs==1.4.3            # via black
-astroid==2.3.3            # via pylint
+astroid==2.4.2            # via pylint
 attrs==19.3.0             # via black, pytest
 black==19.10b0            # via -r requirements-dev.in
 certifi==2019.9.11        # via requests
@@ -29,7 +29,7 @@ pathspec==0.6.0           # via black
 pip-tools==5.2.1          # via -r requirements-dev.in
 pluggy==0.13.1            # via pytest
 py==1.8.0                 # via pytest
-pylint==2.4.4             # via -r requirements-dev.in
+pylint==2.5.3             # via -r requirements-dev.in
 pyparsing==2.4.5          # via packaging
 pytest-asyncio==0.12.0    # via -r requirements-dev.in
 pytest-cov==2.10.0        # via -r requirements-dev.in
@@ -44,7 +44,7 @@ six==1.13.0               # via astroid, freezegun, packaging, pip-tools, python
 snapshottest==0.5.1       # via -r requirements-dev.in
 sqlparse==0.3.0           # via django
 termcolor==1.1.0          # via snapshottest
-toml==0.10.0              # via black
+toml==0.10.0              # via black, pylint
 typed-ast==1.4.0          # via black, mypy
 typing-extensions==3.7.4.1  # via mypy
 urllib3==1.25.7           # via requests


### PR DESCRIPTION
Pylint 2.5 detects when overridden async method is declared as sync (and viceversa), causing PR #385 bumping pylint to fail.

This PR fixes all four linting errors occurring on pylint 2.5.3