### PR TITLE
Don't create custom literal parser by default

### DIFF
--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -1,11 +1,5 @@
-from typing import Any, Dict, Optional, cast
+from typing import Optional, cast
 
-from graphql.language.ast import (
-    BooleanValueNode,
-    FloatValueNode,
-    IntValueNode,
-    StringValueNode,
-)
 from graphql.type import (
     GraphQLNamedType,
     GraphQLScalarLiteralParser,
@@ -14,7 +8,6 @@ from graphql.type import (
     GraphQLScalarValueParser,
     GraphQLSchema,
 )
-from graphql.utilities import value_from_ast_untyped
 
 from .types import SchemaBindable
 
@@ -43,8 +36,6 @@ class ScalarType(SchemaBindable):
 
     def set_value_parser(self, f: GraphQLScalarValueParser) -> GraphQLScalarValueParser:
         self._parse_value = f
-        if not self._parse_literal:
-            self._parse_literal = create_default_literal_parser(f)
         return f
 
     def set_literal_parser(
@@ -79,15 +70,3 @@ class ScalarType(SchemaBindable):
                 "%s is defined in the schema, but it is instance of %s (expected %s)"
                 % (self.name, type(graphql_type).__name__, GraphQLScalarType.__name__)
             )
-
-
-SCALAR_AST_NODES = (BooleanValueNode, FloatValueNode, IntValueNode, StringValueNode)
-
-
-def create_default_literal_parser(
-    value_parser: GraphQLScalarValueParser,
-) -> GraphQLScalarLiteralParser:
-    def default_literal_parser(ast, variable_values: Optional[Dict[str, Any]] = None):
-        return value_parser(value_from_ast_untyped(ast, variable_values))
-
-    return default_literal_parser

--- a/ariadne/scalars.py
+++ b/ariadne/scalars.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import Any, Dict, Optional, cast
 
 from graphql.language.ast import (
     BooleanValueNode,
@@ -87,7 +87,7 @@ SCALAR_AST_NODES = (BooleanValueNode, FloatValueNode, IntValueNode, StringValueN
 def create_default_literal_parser(
     value_parser: GraphQLScalarValueParser,
 ) -> GraphQLScalarLiteralParser:
-    def default_literal_parser(ast):
-        return value_parser(value_from_ast_untyped(ast))
+    def default_literal_parser(ast, variable_values: Optional[Dict[str, Any]] = None):
+        return value_parser(value_from_ast_untyped(ast, variable_values))
 
     return default_literal_parser

--- a/tests/django/test_scalars.py
+++ b/tests/django/test_scalars.py
@@ -82,17 +82,9 @@ def test_date_scalar_has_value_parser_set():
     assert date_scalar._parse_value == parse_date_value
 
 
-def test_date_scalar_has_lister_parser():
-    assert date_scalar._parse_literal
-
-
 def test_datetime_scalar_has_serializer_set():
     assert datetime_scalar._serialize == serialize_datetime
 
 
 def test_datetime_scalar_has_value_parser_set():
     assert datetime_scalar._parse_value == parse_datetime_value
-
-
-def test_datetime_scalar_has_lister_parser():
-    assert datetime_scalar._parse_literal

--- a/tests/test_custom_scalars.py
+++ b/tests/test_custom_scalars.py
@@ -250,18 +250,6 @@ def test_setting_scalar_value_parser_sets_default_literal_parsers_if_none_is_set
     assert schema_scalar.parse_literal
 
 
-def test_setting_scalar_value_parser_doesnt_override_already_set_literal_parser():
-    schema = build_schema(type_defs)
-    scalar = ScalarType("DateInput")
-    scalar.set_literal_parser(parse_date_literal)
-    scalar.set_value_parser(parse_date_value)
-    scalar.bind_to_schema(schema)
-
-    schema_scalar = schema.type_map.get("DateInput")
-    assert schema_scalar.parse_value is parse_date_value
-    assert schema_scalar.parse_literal is parse_date_literal
-
-
 def test_literal_string_is_deserialized_by_default_parser():
     result = graphql_sync(schema, '{ testInputValueType(value: "test") }')
     assert result.errors is None

--- a/tests/test_custom_scalars.py
+++ b/tests/test_custom_scalars.py
@@ -126,6 +126,20 @@ def test_attempt_deserialize_wrong_type_literal_raises_error():
     ]
 
 
+def test_something():
+    test_input = TEST_DATE_SERIALIZED
+    query = """
+        query TestQuery($value: DateInput!) {
+            asValue: testInput(value: $value)
+            asLiteral: testInput(value: "%s")
+        }
+    """ % test_input
+
+    result = graphql_sync(schema, query, variable_values={"value": test_input})
+    assert result.errors is None
+    assert result.data == {'asLiteral': True, 'asValue': True}
+
+
 parametrized_query = """
     query parseValueTest($value: DateInput!) {
         testInput(value: $value)

--- a/tests/test_custom_scalars.py
+++ b/tests/test_custom_scalars.py
@@ -131,20 +131,11 @@ def test_default_literal_parser_is_used_to_extract_value_str_from_ast_node():
     dateinput.set_value_parser(parse_date_value)
     schema = make_executable_schema(type_defs, query, dateinput)
 
-    test_input = TEST_DATE_SERIALIZED
-    test_query = (
-        """
-            query TestQuery($value: DateInput!) {
-                asValue: testInput(value: $value)
-                asLiteral: testInput(value: "%s")
-            }
-        """
-        % test_input
+    result = graphql_sync(
+        schema, """{ testInput(value: "%s") }""" % TEST_DATE_SERIALIZED
     )
-
-    result = graphql_sync(schema, test_query, variable_values={"value": test_input})
     assert result.errors is None
-    assert result.data == {"asValue": True, "asLiteral": True}
+    assert result.data == {"testInput": True}
 
 
 parametrized_query = """


### PR DESCRIPTION
I've did deep dive into GraphQL's query executor and found that if scalar has no literal parser, GraphQL executor will use default one, which did exactly what our default one, eg. convert AST value to python type, then call `parse_value` for field.

In this PR I've added tests cementing this behavior in the core, and removed our fallback default literal parser. I'll also open issue on our docs to remember to update that `parse_literal` is not required if your scalar doesn't need custom AST unpacking logic.

Fixes #371