### PR TITLE
add django-specific uuid and decimal scalars

### DIFF
--- a/ariadne/contrib/django/scalars.py
+++ b/ariadne/contrib/django/scalars.py
@@ -1,5 +1,7 @@
 from datetime import date, datetime
+from decimal import Decimal
 from typing import Any, List, Optional, Union
+import uuid
 
 import dateutil.parser
 from django.forms.utils import from_current_timezone
@@ -14,6 +16,8 @@ datetime_input_formats = formats.get_format_lazy("DATETIME_INPUT_FORMATS")
 
 date_scalar = ScalarType("Date")
 datetime_scalar = ScalarType("DateTime")
+decimal_scalar = ScalarType("Decimal")
+uuid_scalar = ScalarType("UUID")
 
 
 @date_scalar.serializer
@@ -42,6 +46,26 @@ def parse_datetime_value(value: Any) -> datetime:
     if not parsed_value:
         raise ValueError(_("Enter a valid date/time."))
     return from_current_timezone(parsed_value)
+
+
+@decimal_scalar.serializer
+def serialize_decimal(value: Decimal) -> str:
+    return formats.number_format(value)
+
+
+@decimal_scalar.value_parser
+def parse_decimal_value(value: Any) -> Decimal:
+    return Decimal(formats.sanitize_separators(value))
+
+
+@uuid_scalar.serializer
+def serialize_uuid(value: uuid.UUID) -> str:
+    return str(value)
+
+
+@uuid_scalar.value_parser
+def parse_uuid_value(value: str) -> uuid.UUID:
+    return uuid.UUID(value)
 
 
 def parse_value(value: Any, formats: List[str]) -> Optional[datetime]:

--- a/tests/django/test_scalars.py
+++ b/tests/django/test_scalars.py
@@ -112,7 +112,7 @@ def test_uuid_parser_parses_uuid_string():
 
 def test_uuid_parser_raises_value_error_on_invalid_data():
     with pytest.raises(ValueError):
-        parse_datetime_value("meow")
+        parse_uuid_value("nothing")
 
 
 def test_date_scalar_has_serializer_set():

--- a/tests/django/test_scalars.py
+++ b/tests/django/test_scalars.py
@@ -1,14 +1,23 @@
 # pylint: disable=comparison-with-callable,protected-access
+import uuid
+from decimal import ConversionSyntax, Decimal, InvalidOperation
+
 import pytest
 from django.utils import timezone
 
 from ariadne.contrib.django.scalars import (
     date_scalar,
     datetime_scalar,
+    decimal_scalar,
+    uuid_scalar,
     parse_date_value,
     parse_datetime_value,
+    parse_decimal_value,
+    parse_uuid_value,
     serialize_date,
     serialize_datetime,
+    serialize_decimal,
+    serialize_uuid,
 )
 
 
@@ -28,6 +37,15 @@ def test_date_serializer_serializes_datetime(datetime, date):
 
 def test_date_serializer_serializes_date(date):
     assert serialize_date(date) == date.isoformat()
+
+
+def test_decimal_serializer_serializes_decimal():
+    assert serialize_decimal(Decimal("5.0")) == "5.0"
+
+
+def test_uuid_serializer_serializes_uuid():
+    uuid_str = "e6cbf26a-327f-4fd6-9d28-25738a47e303"
+    assert serialize_uuid(uuid.UUID(uuid_str)) == uuid_str
 
 
 def test_date_parser_returns_valid_date_from_datetime_iso8601_str(datetime, date):
@@ -74,6 +92,29 @@ def test_datetime_parser_raises_value_error_on_invalid_data():
         parse_datetime_value("nothing")
 
 
+def test_decimal_parser_parses_string():
+    assert parse_decimal_value("5.0") == Decimal("5.0")
+
+
+def test_decimal_parser_parses_integer():
+    assert parse_decimal_value(5) == Decimal("5")
+
+
+def test_decimal_parser_raises_conversion_syntax_on_invalid_data():
+    with pytest.raises(InvalidOperation):
+        parse_decimal_value("meow")
+
+
+def test_uuid_parser_parses_uuid_string():
+    uuid_str = "bb7efd70-b1cd-11ea-a5af-0242ac130006"
+    assert parse_uuid_value(uuid_str) == uuid.UUID(uuid_str)
+
+
+def test_uuid_parser_raises_value_error_on_invalid_data():
+    with pytest.raises(ValueError):
+        parse_datetime_value("meow")
+
+
 def test_date_scalar_has_serializer_set():
     assert date_scalar._serialize == serialize_date
 
@@ -88,3 +129,19 @@ def test_datetime_scalar_has_serializer_set():
 
 def test_datetime_scalar_has_value_parser_set():
     assert datetime_scalar._parse_value == parse_datetime_value
+
+
+def test_decimal_scalar_has_serializer_set():
+    assert decimal_scalar._serialize == serialize_decimal
+
+
+def test_decimal_scalar_has_value_parser_set():
+    assert decimal_scalar._parse_value == parse_decimal_value
+
+
+def test_uuid_scalar_has_serializer_set():
+    assert uuid_scalar._serialize == serialize_uuid
+
+
+def test_uuid_scalar_has_value_parser_set():
+    assert uuid_scalar._parse_value == parse_uuid_value

--- a/tests/django/test_scalars.py
+++ b/tests/django/test_scalars.py
@@ -100,7 +100,7 @@ def test_decimal_parser_parses_integer():
     assert parse_decimal_value(5) == Decimal("5")
 
 
-def test_decimal_parser_raises_conversion_syntax_on_invalid_data():
+def test_decimal_parser_raises_invalid_operation_on_invalid_data():
     with pytest.raises(InvalidOperation):
         parse_decimal_value("meow")
 

--- a/tests/django/test_scalars.py
+++ b/tests/django/test_scalars.py
@@ -1,6 +1,6 @@
 # pylint: disable=comparison-with-callable,protected-access
 import uuid
-from decimal import ConversionSyntax, Decimal, InvalidOperation
+from decimal import Decimal, InvalidOperation
 
 import pytest
 from django.utils import timezone


### PR DESCRIPTION
Provides scalars for commonly used django types - UUID and Decimal.  Incorrect decimal parsing can lead to unpleasant data quality issues, so providing an opinionated scalar that follow's django's best practices is advised.

Docs PR: https://github.com/mirumee/ariadne-website/pull/57