### PR TITLE
hand connection_init message payload to subscription context

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -218,41 +218,38 @@ class GraphQL:
     async def websocket_server(self, websocket: WebSocket) -> None:
         subscriptions: Dict[str, AsyncGenerator] = {}
         await websocket.accept("graphql-ws")
+        connection_init_payload = None
         try:
             while (
                 websocket.client_state != WebSocketState.DISCONNECTED
                 and websocket.application_state != WebSocketState.DISCONNECTED
             ):
                 message = await websocket.receive_json()
-                await self.handle_websocket_message(message, websocket, subscriptions)
+
+                operation_id = cast(str, message.get("id"))
+                message_type = cast(str, message.get("type"))
+
+                if message_type == GQL_CONNECTION_INIT:
+                    await websocket.send_json({"type": GQL_CONNECTION_ACK})
+                    asyncio.ensure_future(self.keep_websocket_alive(websocket))
+                    # GraphQL Playground sends header data in the connection_init message payload
+                    # therefore the payload will be handed to the subscription context
+                    connection_init_payload = message.get('payload')
+                elif message_type == GQL_CONNECTION_TERMINATE:
+                    await websocket.close()
+                elif message_type == GQL_START:
+                    await self.start_websocket_subscription(
+                        message.get("payload"), connection_init_payload, operation_id, websocket, subscriptions
+                    )
+                elif message_type == GQL_STOP:
+                    if operation_id in subscriptions:
+                        await subscriptions[operation_id].aclose()
+                        del subscriptions[operation_id]
         except WebSocketDisconnect:
             pass
         finally:
             for operation_id in subscriptions:
                 await subscriptions[operation_id].aclose()
-
-    async def handle_websocket_message(
-        self,
-        message: dict,
-        websocket: WebSocket,
-        subscriptions: Dict[str, AsyncGenerator],
-    ):
-        operation_id = cast(str, message.get("id"))
-        message_type = cast(str, message.get("type"))
-
-        if message_type == GQL_CONNECTION_INIT:
-            await websocket.send_json({"type": GQL_CONNECTION_ACK})
-            asyncio.ensure_future(self.keep_websocket_alive(websocket))
-        elif message_type == GQL_CONNECTION_TERMINATE:
-            await websocket.close()
-        elif message_type == GQL_START:
-            await self.start_websocket_subscription(
-                message.get("payload"), operation_id, websocket, subscriptions
-            )
-        elif message_type == GQL_STOP:
-            if operation_id in subscriptions:
-                await subscriptions[operation_id].aclose()
-                del subscriptions[operation_id]
 
     async def keep_websocket_alive(self, websocket: WebSocket):
         if not self.keepalive:
@@ -267,11 +264,13 @@ class GraphQL:
     async def start_websocket_subscription(
         self,
         data: Any,
+        connection_init_payload: Any,
         operation_id: str,
         websocket: WebSocket,
         subscriptions: Dict[str, AsyncGenerator],
     ):
         context_value = await self.get_context_for_request(websocket)
+        context_value['connection_init_payload'] = connection_init_payload
         success, results = await subscribe(
             self.schema,
             data,

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -234,12 +234,16 @@ class GraphQL:
                     asyncio.ensure_future(self.keep_websocket_alive(websocket))
                     # GraphQL Playground sends header data in the connection_init message payload
                     # therefore the payload will be handed to the subscription context
-                    connection_init_payload = message.get('payload')
+                    connection_init_payload = message.get("payload")
                 elif message_type == GQL_CONNECTION_TERMINATE:
                     await websocket.close()
                 elif message_type == GQL_START:
                     await self.start_websocket_subscription(
-                        message.get("payload"), connection_init_payload, operation_id, websocket, subscriptions
+                        message.get("payload"),
+                        connection_init_payload,
+                        operation_id,
+                        websocket,
+                        subscriptions,
                     )
                 elif message_type == GQL_STOP:
                     if operation_id in subscriptions:
@@ -270,7 +274,7 @@ class GraphQL:
         subscriptions: Dict[str, AsyncGenerator],
     ):
         context_value = await self.get_context_for_request(websocket)
-        context_value['connection_init_payload'] = connection_init_payload
+        context_value["connection_init_payload"] = connection_init_payload
         success, results = await subscribe(
             self.schema,
             data,


### PR DESCRIPTION
For websocket subscriptions, GraphQL Playground sends header data (e.g. for authorization) in the `connection_init` message payload. In the current Ariadne implementation this data is discarded. My fix persists the payload from the `connection_init` message and hands it to the `start_websocket_subscription` method when the `start` message arrives. The payload data is then stored in the `context` dictionary.

I moved the method code from `handle_websocket_message` to `websocket_server` and deleted `handle_websocket_message`, because with the stateful behaviour introduced by my fix it seems more elegant this way.