### PR TITLE
Expose websockets for auth (improved)

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -28,11 +28,11 @@ from .format_error import format_error
 from .graphql import graphql, subscribe
 from .logger import log_error
 from .types import (
-    OnConnect,
-    OnClose,
     ContextValue,
     ErrorFormatter,
     Extension,
+    OnClose,
+    OnConnect,
     RootValue,
     ValidationRules,
 )

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -239,7 +239,9 @@ class GraphQL:
                 and websocket.application_state != WebSocketState.DISCONNECTED
             ):
                 message = await websocket.receive_json()
-                await self.handle_websocket_message(message, websocket, subscriptions, context_value)
+                await self.handle_websocket_message(
+                    message, websocket, subscriptions, context_value
+                )
         except WebSocketDisconnect:
             pass
         finally:

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -253,7 +253,7 @@ class GraphQL:
         message: dict,
         websocket: WebSocket,
         subscriptions: Dict[str, AsyncGenerator],
-        context_value: Any,
+        context_value: ContextValue,
     ):
         operation_id = cast(str, message.get("id"))
         message_type = cast(str, message.get("type"))
@@ -302,7 +302,7 @@ class GraphQL:
         operation_id: str,
         websocket: WebSocket,
         subscriptions: Dict[str, AsyncGenerator],
-        context_value: Any,
+        context_value: ContextValue,
     ):
         success, results = await subscribe(
             self.schema,

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -8,7 +8,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    Union,
+    Union
 )
 from typing_extensions import Protocol
 
@@ -34,9 +34,9 @@ SubscriptionResult = Tuple[
 Subscriber = Callable[..., AsyncGenerator]
 ErrorFormatter = Callable[[GraphQLError, bool], dict]
 
-OnConnect = Callable[[dict, WebSocket], None]
-OnClose = Callable[[dict, WebSocket], None]
 ContextValue = Union[Any, Callable[[Any], Any]]
+OnConnect = Callable[[dict, ContextValue], Any]
+OnClose = Callable[[dict, ContextValue], Any]
 RootValue = Union[Any, Callable[[Optional[Any], DocumentNode], Any]]
 
 ValidationRules = Union[

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -12,6 +12,8 @@ from typing import (
 )
 from typing_extensions import Protocol
 
+from starlette.websockets import WebSocket
+
 from graphql import (
     DocumentNode,
     ExecutionResult,
@@ -32,6 +34,8 @@ SubscriptionResult = Tuple[
 Subscriber = Callable[..., AsyncGenerator]
 ErrorFormatter = Callable[[GraphQLError, bool], dict]
 
+OnConnect = Callable[[dict, WebSocket], None]
+OnClose = Callable[[dict, WebSocket], None]
 ContextValue = Union[Any, Callable[[Any], Any]]
 RootValue = Union[Any, Callable[[Optional[Any], DocumentNode], Any]]
 

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -8,7 +8,7 @@ from typing import (
     Sequence,
     Tuple,
     Type,
-    Union
+    Union,
 )
 from typing_extensions import Protocol
 

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -12,8 +12,6 @@ from typing import (
 )
 from typing_extensions import Protocol
 
-from starlette.websockets import WebSocket
-
 from graphql import (
     DocumentNode,
     ExecutionResult,


### PR DESCRIPTION
I have improved the open pull request https://github.com/mirumee/ariadne/pull/355.

1. I rebased the original pull request to the current master branch
2. My code can handle async or normal `on_connect` and `on_close` functions as requested in https://github.com/mirumee/ariadne/pull/355#discussion_r416528840
3. The `context_value` is now created earlier in the `websocket_server` and is passed to all the other functions. It is also passed  to `on_connect` and `on_close`, instead of the websocket object (because this object is included in the context by default anyway). The user can therefore add content to the context inside of `on_connect` (e.g. message payload) that can then be reused in a resolver.