### PR TITLE
Fix cost multiplier to accept nested variables

### DIFF
--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -86,9 +86,12 @@ class CostValidator(ValidationRule):
                     continue
                 field_type = get_named_type(field.type)
                 try:
-                    field_args = get_argument_values(field, child_node, self.variables)
+                    field_args: Dict[str, Any] = get_argument_values(
+                        field, child_node, self.variables
+                    )
                 except Exception as e:
                     report_error(self.context, e)
+                    field_args = {}
                 if self.cost_map:
                     cost_map_args = (
                         self.get_args_from_cost_map(

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -256,7 +256,7 @@ class CostValidator(ValidationRule):
                 if complexity_arg
                 and complexity_arg.value
                 and isinstance(complexity_arg.value, IntValueNode)
-                else []
+                else None
             )
             return {
                 "complexity": complexity,

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from operator import add, mul
-from typing import Any, Dict, List, Optional, Union, cast
+from typing import Any, Dict, List, Optional, Type, Union, cast
 
 from graphql import (
     GraphQLError,
@@ -9,6 +9,7 @@ from graphql import (
     GraphQLSchema,
     get_named_type,
 )
+from graphql.execution.values import get_argument_values
 from graphql.language import (
     BooleanValueNode,
     FieldNode,
@@ -22,7 +23,6 @@ from graphql.language import (
     OperationType,
     StringValueNode,
 )
-from graphql.execution.values import get_argument_values
 from graphql.type import GraphQLFieldMap
 from graphql.validation import ValidationContext
 from graphql.validation.rules import ASTValidationRule, ValidationRule
@@ -341,7 +341,7 @@ def cost_validator(
     default_complexity: int = 1,
     variables: Optional[Dict] = None,
     cost_map: Optional[Dict[str, Dict[str, Any]]] = None,
-) -> ASTValidationRule:
+) -> Type[ASTValidationRule]:
     class _CostValidator(CostValidator):
         def __init__(self, context: ValidationContext):
             super().__init__(
@@ -353,4 +353,4 @@ def cost_validator(
                 cost_map=cost_map,
             )
 
-    return cast(ASTValidationRule, _CostValidator)
+    return cast(Type[ASTValidationRule], _CostValidator)

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -272,7 +272,13 @@ class CostValidator(ValidationRule):
         return self.get_multipliers_from_string(multipliers, field_args)  # type: ignore
 
     def get_multipliers_from_string(self, multipliers: List[str], field_args):
-        multipliers = [field_args.get(multiplier) for multiplier in multipliers]
+        accessors = [s.split(".") for s in multipliers]
+        multipliers = []
+        for accessor in accessors:
+            val = field_args
+            for key in accessor:
+                val = val.get(key)
+            multipliers.append(val)
         multipliers = [
             len(multiplier) if isinstance(multiplier, (list, tuple)) else multiplier
             for multiplier in multipliers

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -368,4 +368,3 @@ def test_child_field_cost_defined_in_directive_is_multiplied_by_values_from_lite
             extensions={"cost": {"requestedQueryCost": 20, "maximumAvailable": 3}},
         )
     ]
-

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -47,6 +47,7 @@ def schema_with_costs():
             constant: Int! @cost(complexity: 3)
             simple(value: Int!): Int! @cost(complexity: 1, multipliers: ["value"])
             complex(valueA: Int!, valueB: Int!): Int! @cost(complexity: 1, multipliers: ["valueA", "valueB"])
+            noComplexity(value: Int!): Int! @cost(multipliers: ["value"])
             nested(value: NestedInput!): Int! @cost(complexity: 1, multipliers: ["value.num"])
             child(value: Int!): [Child!]! @cost(complexity: 1, multipliers: ["value"])
         }
@@ -191,6 +192,25 @@ def test_field_cost_defined_in_directive_is_multiplied_by_value_from_variables(
     query = """
         query testQuery($value: Int!) {
             simple(value: $value)
+        }
+    """
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=3, variables={"value": 5})
+    result = validate(schema_with_costs, ast, [rule])
+    assert result == [
+        GraphQLError(
+            "The query exceeds the maximum cost of 3. Actual cost is 5",
+            extensions={"cost": {"requestedQueryCost": 5, "maximumAvailable": 3}},
+        )
+    ]
+
+
+def test_default_values_are_used_to_calculate_query_cost_without_directive_args(
+    schema_with_costs,
+):
+    query = """
+        query testQuery($value: Int!) {
+            noComplexity(value: $value)
         }
     """
     ast = parse(query)


### PR DESCRIPTION
This PR makes a query cost validator to accept deep nested variables like `input` type values.
For example, when a multiplier name is `foo.bar.baz` ,  the multiplier value is `{"foo" : {"bar" : {"baz" : <value>}}}` .

See https://github.com/pa-bru/graphql-cost-analysis#cost-settings-arguments

note: CRLF was used in the 2 changed files, but most of `ariadne` used LF, so I fixed that newlines. 