### PR TITLE
Default union type resolver

### DIFF
--- a/ariadne/interfaces.py
+++ b/ariadne/interfaces.py
@@ -8,17 +8,20 @@ from graphql.type import (
 )
 
 from .objects import ObjectType
-from .types import Resolver
+from .resolvers import default_type_resolver
+from .types import TypeResolver
 
 
 class InterfaceType(ObjectType):
-    _resolve_type: Optional[Resolver]
+    _resolve_type: TypeResolver
 
-    def __init__(self, name: str, type_resolver: Optional[Resolver] = None) -> None:
+    def __init__(
+        self, name: str, type_resolver: TypeResolver = default_type_resolver
+    ) -> None:
         super().__init__(name)
         self._resolve_type = type_resolver
 
-    def set_type_resolver(self, type_resolver: Resolver) -> Resolver:
+    def set_type_resolver(self, type_resolver: TypeResolver) -> TypeResolver:
         self._resolve_type = type_resolver
         return type_resolver
 

--- a/ariadne/resolvers.py
+++ b/ariadne/resolvers.py
@@ -63,3 +63,7 @@ def is_default_resolver(resolver: Resolver) -> bool:
     if resolver == default_field_resolver:
         return True
     return hasattr(resolver, "_ariadne_alias_resolver")
+
+
+def default_type_resolver(obj: Any, *_: Any) -> str:
+    return type(obj).__name__

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -43,6 +43,11 @@ ValidationRules = Union[
 ]
 
 
+class TypeResolver(Protocol):
+    def __call__(self, obj: Any, *_: Any) -> Optional[str]:
+        pass  # pragma: no cover
+
+
 class Extension(Protocol):
     def request_started(self, context: ContextValue):
         pass  # pragma: no cover

--- a/ariadne/unions.py
+++ b/ariadne/unions.py
@@ -2,17 +2,17 @@ from typing import Optional, cast
 
 from graphql.type import GraphQLNamedType, GraphQLUnionType, GraphQLSchema
 
-from .types import Resolver, SchemaBindable
+from .types import SchemaBindable, TypeResolver
 
 
 class UnionType(SchemaBindable):
-    _resolve_type: Optional[Resolver]
+    _resolve_type: Optional[TypeResolver]
 
-    def __init__(self, name: str, type_resolver: Optional[Resolver] = None) -> None:
+    def __init__(self, name: str, type_resolver: Optional[TypeResolver] = None) -> None:
         self.name = name
         self._resolve_type = type_resolver
 
-    def set_type_resolver(self, type_resolver: Resolver) -> Resolver:
+    def set_type_resolver(self, type_resolver: TypeResolver) -> TypeResolver:
         self._resolve_type = type_resolver
         return type_resolver
 

--- a/ariadne/unions.py
+++ b/ariadne/unions.py
@@ -2,13 +2,16 @@ from typing import Optional, cast
 
 from graphql.type import GraphQLNamedType, GraphQLUnionType, GraphQLSchema
 
+from .resolvers import default_type_resolver
 from .types import SchemaBindable, TypeResolver
 
 
 class UnionType(SchemaBindable):
-    _resolve_type: Optional[TypeResolver]
+    _resolve_type: TypeResolver
 
-    def __init__(self, name: str, type_resolver: Optional[TypeResolver] = None) -> None:
+    def __init__(
+        self, name: str, type_resolver: TypeResolver = default_type_resolver
+    ) -> None:
         self.name = name
         self._resolve_type = type_resolver
 

--- a/tests/test_default_type_resolver.py
+++ b/tests/test_default_type_resolver.py
@@ -1,0 +1,100 @@
+from attr import dataclass
+
+import pytest
+from graphql import graphql_sync
+
+from ariadne import (
+    QueryType,
+    UnionType,
+    make_executable_schema,
+)
+
+type_defs = """
+    union Result = Book | Author
+
+    type Book {
+        title: String
+    }
+
+    type Author {
+        name: String
+    }
+
+    type Query {
+        item: Result
+    }
+"""
+
+
+test_query = """
+    {
+        item {
+            __typename
+            ... on Book {
+                title
+            }
+            ... on Author {
+                name
+            }
+        }
+    }
+"""
+
+
+@dataclass
+class Book:
+    title: str = "Shantaram"
+
+
+@dataclass
+class Author:
+    name: str = "Gregory David Roberts"
+
+
+@pytest.fixture
+def query():
+    return QueryType()
+
+
+@pytest.fixture
+def query_with_book_item(query):
+    query.set_field("item", lambda *_: Book())
+    return query
+
+
+@pytest.fixture
+def query_with_author_item(query):
+    query.set_field("item", lambda *_: Author())
+    return query
+
+
+@pytest.fixture
+def query_with_none_item(query):
+    query.set_field("item", lambda *_: 42)
+    return query
+
+
+@pytest.fixture
+def union_type():
+    union = UnionType("Result")
+    return union
+
+
+def test_default_type_resolver_foo(query_with_book_item, union_type):
+    schema = make_executable_schema(type_defs, [query_with_book_item, union_type])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {"item": {"__typename": "Book", "title": "Shantaram"}}
+
+
+def test_default_type_resolver_bar(query_with_author_item, union_type):
+    schema = make_executable_schema(type_defs, [query_with_author_item, union_type])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {
+        "item": {"__typename": "Author", "name": "Gregory David Roberts"}
+    }
+
+
+def test_default_type_resolver_None(query_with_none_item, union_type):
+    schema = make_executable_schema(type_defs, [query_with_none_item, union_type])
+    result = graphql_sync(schema, test_query)
+    assert result.data == {"item": None}


### PR DESCRIPTION
## Problem

Currently handling **UnionTypes** requires writing a boiler-plate type resolver. It tends to be irritating, especially for big unions.

Example from [docs](https://ariadnegraphql.org/docs/next/unions#union-example):
```python
from ariadne import UnionType

error = UnionType("Error")

@error.type_resolver
def resolve_error_type(obj, *_):
    if isinstance(obj, ValidationError):
        return "ValidationError"
    if isinstance(obj, AccessError):
        return "AccessError"
    return None
```

## Solution
Default type resolver. You can still set a custom `type_resolver`, but the common behaviour is the default.

```python
def default_type_resolver(obj: Any, *_: Any) -> str:
    return type(obj).__name__
```
