### PR TITLE
Ensure None entities are returned as such during federation (without appending typename)

### DIFF
--- a/ariadne/contrib/federation/utils.py
+++ b/ariadne/contrib/federation/utils.py
@@ -137,4 +137,4 @@ def add_typename_to_possible_return(obj: Any, typename: str) -> Any:
         else:
             setattr(obj, f"_{obj.__class__.__name__}__typename", typename)
         return obj
-    return {"__typename": typename}
+    return None

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -465,8 +465,7 @@ def test_federated_schema_execute_reference_resolver_that_returns_none():
     )
 
     assert result.errors is None
-    assert result.data["_entities"][0]["__typename"] == "Product"
-    assert result.data["_entities"][0]["name"] is None
+    assert result.data['_entities'][0] is None
 
 
 def test_federated_schema_raises_error_on_missing_type():


### PR DESCRIPTION
Hello! My original federation PR contained an oversight on my part that wrongly added `__typename` to `None` when resolving entities. As can be seen in the [federation specs](https://www.apollographql.com/docs/federation/federation-spec/) and the original [federation-js source](https://github.com/apollographql/federation/blob/49fc528be1c2796b09fe7dff4f8cbe604b39a3fb/federation-js/src/types.ts#L44), the typename should not be added, as entities can return a non-nullable list of nullable `_Entity` types.

This PR addresses this oversight and tweaks one of the test files. Cheers!