### PR TITLE
Updated convert_camel_case_to_snake to handle more edge cases.

### DIFF
--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -8,7 +8,7 @@ from graphql import GraphQLError, parse
 def convert_camel_case_to_snake(graphql_name: str) -> str:
     python_name = ""
     for i, c in enumerate(graphql_name.lower()):
-        if i and c != graphql_name[i]:
+        if i and c != graphql_name[i] and i > 0 and graphql_name[i - 1] != "_":
             python_name += "_"
         python_name += c
     return python_name

--- a/tests/test_case_convertion_util.py
+++ b/tests/test_case_convertion_util.py
@@ -34,3 +34,7 @@ def test_three_words_pascal_case_name_is_converted():
 
 def test_three_words_camel_case_name_is_converted():
     assert convert_camel_case_to_snake("testComplexName") == "test_complex_name"
+
+
+def test_no_underscore_added_if_previous_character_is_an_underscore():
+    assert convert_camel_case_to_snake("test__complexName") == "test__complex_name"


### PR DESCRIPTION
Updated convert_camel_case_to_snake to not add an additional underscore, if the previous char was already one.

This is useful for example for django users, when using it's nested lookups.
The previous version of the convert_camel_case_to_snake would add an additional underscore to the string, the new one prevents this behaviour.

So passing a string like "user__accountId" now results in "user__account_id" (2 underscores) instead of "user___account_id" (3 underscores).