### PR TITLE
Do not add underscores in block capitals in identifiers

### DIFF
--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -11,7 +11,6 @@ def convert_camel_case_to_snake(graphql_name: str) -> str:
         if (
             i
             and c != graphql_name[i]
-            and i > 0
             and graphql_name[i - 1] != "_"
             and graphql_name[i - 1] == python_name[-1]
         ):

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -8,7 +8,13 @@ from graphql import GraphQLError, parse
 def convert_camel_case_to_snake(graphql_name: str) -> str:
     python_name = ""
     for i, c in enumerate(graphql_name.lower()):
-        if i and c != graphql_name[i] and i > 0 and graphql_name[i - 1] != "_":
+        if (
+            i
+            and c != graphql_name[i]
+            and i > 0
+            and graphql_name[i - 1] != "_"
+            and graphql_name[i - 1] == python_name[-1]
+        ):
             python_name += "_"
         python_name += c
     return python_name

--- a/tests/test_case_convertion_util.py
+++ b/tests/test_case_convertion_util.py
@@ -38,3 +38,7 @@ def test_three_words_camel_case_name_is_converted():
 
 def test_no_underscore_added_if_previous_character_is_an_underscore():
     assert convert_camel_case_to_snake("test__complexName") == "test__complex_name"
+
+
+def test_no_underscore_added_if_previous_character_is_uppercase():
+    assert convert_camel_case_to_snake("testWithUPPERPart") == "test_with_upperpart"


### PR DESCRIPTION
Do not add an underscore, if the previous character was also upper case.

This is useful if you have an acronym in an identifier. Specifically, I encountered this with the identifier `interfaceMACs`, which converted to `interface_m_a_cs`. With this change the identifier converts to `interface_macs`.