### PR TITLE
Added support for numbers in camelCase variables.

### DIFF
--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -9,11 +9,18 @@ def convert_camel_case_to_snake(graphql_name: str) -> str:
     python_name = ""
     for i, c in enumerate(graphql_name.lower()):
         if (
-            i
-            and c != graphql_name[i]
-            and graphql_name[i - 1] != "_"
-            and graphql_name[i - 1] == python_name[-1]
-        ) or (i and c.isdigit() and graphql_name[i - 1].isdigit() is False):
+            i > 0
+            and (
+                all(
+                    (
+                        c != graphql_name[i],
+                        graphql_name[i - 1] != "_",
+                        graphql_name[i - 1] == python_name[-1],
+                    )
+                )
+            )
+            or all((c.isdigit(), graphql_name[i - 1].isdigit() is False))
+        ):
             python_name += "_"
         python_name += c
     return python_name

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -13,7 +13,7 @@ def convert_camel_case_to_snake(graphql_name: str) -> str:
             and c != graphql_name[i]
             and graphql_name[i - 1] != "_"
             and graphql_name[i - 1] == python_name[-1]
-        ):
+        ) or (i and c.isdigit() and graphql_name[i - 1].isdigit() is False):
             python_name += "_"
         python_name += c
     return python_name

--- a/tests/test_case_convertion_util.py
+++ b/tests/test_case_convertion_util.py
@@ -44,5 +44,5 @@ def test_no_underscore_added_if_previous_character_is_uppercase():
     assert convert_camel_case_to_snake("testWithUPPERPart") == "test_with_upperpart"
 
 
-def test_number_gets_treated_as_word():
+def test_digits_are_treated_as_word():
     assert convert_camel_case_to_snake("testWith365InIt") == "test_with_365_in_it"

--- a/tests/test_case_convertion_util.py
+++ b/tests/test_case_convertion_util.py
@@ -42,3 +42,7 @@ def test_no_underscore_added_if_previous_character_is_an_underscore():
 
 def test_no_underscore_added_if_previous_character_is_uppercase():
     assert convert_camel_case_to_snake("testWithUPPERPart") == "test_with_upperpart"
+
+
+def test_number_gets_treated_as_word():
+    assert convert_camel_case_to_snake("testWith365InIt") == "test_with_365_in_it"


### PR DESCRIPTION
The previous version of the 'convert_camel_case_to_snake' utility function did not handle numbers inside the 'graphql_name'.

So passing a string like "foo365Bar" woud have resulted in "foo365_bar".

Now it would result in: "foo_365_bar"