### PR TITLE
Fixed type annotation for extensions list

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -9,7 +9,6 @@ from typing import (
     List,
     Optional,
     Union,
-    Type,
     cast,
 )
 
@@ -27,7 +26,7 @@ from .file_uploads import combine_multipart_data
 from .format_error import format_error
 from .graphql import graphql, subscribe
 from .logger import log_error
-from .types import ContextValue, ErrorFormatter, Extension, RootValue, ValidationRules
+from .types import ContextValue, ErrorFormatter, ExtensionList, RootValue, ValidationRules
 
 GQL_CONNECTION_INIT = "connection_init"  # Client -> Server
 GQL_CONNECTION_ACK = "connection_ack"  # Server -> Client
@@ -43,7 +42,6 @@ GQL_ERROR = "error"  # Server -> Client
 GQL_COMPLETE = "complete"  # Server -> Client
 GQL_STOP = "stop"  # Client -> Server
 
-ExtensionList = Optional[List[Type[Extension]]]
 Extensions = Union[
     Callable[[Any, Optional[ContextValue]], ExtensionList], ExtensionList
 ]

--- a/ariadne/contrib/django/views.py
+++ b/ariadne/contrib/django/views.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Callable, List, Optional, Type, Union, cast
+from typing import Any, Callable, Optional, Union, cast
 
 from django.conf import settings
 from django.http import HttpRequest, HttpResponseBadRequest, JsonResponse
@@ -18,13 +18,12 @@ from ...graphql import graphql_sync
 from ...types import (
     ContextValue,
     ErrorFormatter,
-    Extension,
+    ExtensionList,
     GraphQLResult,
     RootValue,
     ValidationRules,
 )
 
-ExtensionList = Optional[List[Type[Extension]]]
 Extensions = Union[
     Callable[[Any, Optional[ContextValue]], ExtensionList], ExtensionList
 ]

--- a/ariadne/extensions.py
+++ b/ariadne/extensions.py
@@ -1,10 +1,10 @@
 from contextlib import contextmanager
-from typing import List, Optional, Type
+from typing import List, Optional
 
 from graphql import GraphQLError
 from graphql.execution import MiddlewareManager
 
-from .types import ContextValue, Extension
+from .types import ContextValue, ExtensionList
 
 
 class ExtensionManager:
@@ -12,7 +12,7 @@ class ExtensionManager:
 
     def __init__(
         self,
-        extensions: Optional[List[Type[Extension]]] = None,
+        extensions: ExtensionList = None,
         context: ContextValue = None,
     ):
         self.context = context

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -22,7 +22,7 @@ from .format_error import format_error
 from .logger import log_error
 from .types import (
     ErrorFormatter,
-    Extension,
+    ExtensionList,
     GraphQLResult,
     RootValue,
     SubscriptionResult,
@@ -45,7 +45,7 @@ async def graphql(
     validation_rules: Optional[ValidationRules] = None,
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
-    extensions: Optional[List[Type[Extension]]] = None,
+    extensions: ExtensionList = None,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions, context_value)
@@ -128,7 +128,7 @@ def graphql_sync(
     validation_rules: Optional[ValidationRules] = None,
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
-    extensions: Optional[List[Type[Extension]]] = None,
+    extensions: ExtensionList = None,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions, context_value)

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -42,6 +42,8 @@ ValidationRules = Union[
     ],
 ]
 
+ExtensionList = Optional[List[Union[Type["Extension"], Callable[[], "Extension"]]]]
+
 
 class Extension(Protocol):
     def request_started(self, context: ContextValue):

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -1,6 +1,6 @@
 import json
 from cgi import FieldStorage
-from typing import Any, Callable, List, Optional, Type, Union
+from typing import Any, Callable, List, Optional, Union
 
 from graphql import GraphQLError, GraphQLSchema
 from graphql.execution import Middleware, MiddlewareManager
@@ -22,13 +22,12 @@ from .graphql import graphql_sync
 from .types import (
     ContextValue,
     ErrorFormatter,
-    Extension,
+    ExtensionList,
     GraphQLResult,
     RootValue,
     ValidationRules,
 )
 
-ExtensionList = Optional[List[Type[Extension]]]
 Extensions = Union[
     Callable[[Any, Optional[ContextValue]], ExtensionList], ExtensionList
 ]


### PR DESCRIPTION
This consolidates the definition of the ExtensionList type into ariadne.types, where it can be referenced by everything that needs it.

The type definition has been updated to support a list of both Extension classes and callables that return Extension objects. This should be allowed since all that's happening with the items in this list is calling them: https://github.com/mirumee/ariadne/blob/master/ariadne/extensions.py#L21