### PR TITLE
Update GraphQL core to latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.13.0 (unreleased)
 
-- Updated GraphQL-core requirement to 3.1.0.
+- Updated GraphQL-core requirement to 3.1.3.
 
 
 ## 0.12.0 (2020-08-04)

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -26,7 +26,13 @@ from .file_uploads import combine_multipart_data
 from .format_error import format_error
 from .graphql import graphql, subscribe
 from .logger import log_error
-from .types import ContextValue, ErrorFormatter, ExtensionList, RootValue, ValidationRules
+from .types import (
+    ContextValue,
+    ErrorFormatter,
+    ExtensionList,
+    RootValue,
+    ValidationRules,
+)
 
 GQL_CONNECTION_INIT = "connection_init"  # Client -> Server
 GQL_CONNECTION_ACK = "connection_ack"  # Server -> Client

--- a/ariadne/contrib/federation/utils.py
+++ b/ariadne/contrib/federation/utils.py
@@ -115,7 +115,7 @@ def includes_directive(
         return False
 
     directives = gather_directives(type_object)
-    return any([d.name.value == directive_name for d in directives])
+    return any(d.name.value == directive_name for d in directives)
 
 
 def gather_directives(

--- a/ariadne/schema_visitor.py
+++ b/ariadne/schema_visitor.py
@@ -563,7 +563,9 @@ def heal_schema(schema: GraphQLSchema) -> GraphQLSchema:
 
         each(type_.fields, _heal_field)
 
-    def heal_type(type_: GraphQLNamedType) -> GraphQLNamedType:
+    def heal_type(
+        type_: Union[GraphQLList, GraphQLNamedType, GraphQLNonNull]
+    ) -> Union[GraphQLList, GraphQLNamedType, GraphQLNonNull]:
         # Unwrap the two known wrapper types
         if isinstance(type_, GraphQLList):
             type_ = GraphQLList(heal_type(type_.of_type))

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file=requirements.txt setup.py
 #
-
-graphql-core==3.1.1       # via ariadne (setup.py)
-starlette==0.13.2         # via ariadne (setup.py)
-typing-extensions==3.7.4.1  # via ariadne (setup.py)
+graphql-core==3.1.3
+starlette==0.14.2
+typing-extensions==3.7.4.3


### PR DESCRIPTION
This PR updates GraphQL core to latest version: 3.1.3