### PR TITLE
Fix #442, append underscore when word is followed by digits

### DIFF
--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -6,20 +6,29 @@ from graphql import GraphQLError, parse
 
 
 def convert_camel_case_to_snake(graphql_name: str) -> str:
+    # pylint: disable=too-many-boolean-expressions
+    max_index = len(graphql_name) - 1
+    lowered_name = graphql_name.lower()
+
     python_name = ""
-    for i, c in enumerate(graphql_name.lower()):
-        if (
-            i > 0
-            and (
-                all(
-                    (
-                        c != graphql_name[i],
-                        graphql_name[i - 1] != "_",
-                        graphql_name[i - 1] == python_name[-1],
-                    )
-                )
+    for i, c in enumerate(lowered_name):
+        if i > 0 and (
+            # testWord -> test_word
+            (
+                c != graphql_name[i]
+                and graphql_name[i - 1] != "_"
+                and graphql_name[i - 1] == python_name[-1]
             )
-            or all((c.isdigit(), graphql_name[i - 1].isdigit() is False))
+            # TESTWord -> test_word
+            or (
+                i < max_index
+                and graphql_name[i] != lowered_name[i]
+                and graphql_name[i + 1] == lowered_name[i + 1]
+            )
+            # test134 -> test_134
+            or (c.isdigit() and not graphql_name[i - 1].isdigit())
+            # 134test -> 134_test
+            or (not c.isdigit() and graphql_name[i - 1].isdigit())
         ):
             python_name += "_"
         python_name += c

--- a/tests/test_camel_case_to_snake_case_convertion.py
+++ b/tests/test_camel_case_to_snake_case_convertion.py
@@ -1,3 +1,5 @@
+import pytest
+
 from ariadne import convert_camel_case_to_snake
 
 
@@ -41,8 +43,16 @@ def test_no_underscore_added_if_previous_character_is_an_underscore():
 
 
 def test_no_underscore_added_if_previous_character_is_uppercase():
-    assert convert_camel_case_to_snake("testWithUPPERPart") == "test_with_upperpart"
+    assert convert_camel_case_to_snake("testWithUPPERPart") == "test_with_upper_part"
 
 
-def test_digits_are_treated_as_word():
-    assert convert_camel_case_to_snake("testWith365InIt") == "test_with_365_in_it"
+@pytest.mark.parametrize(
+    ("test_str", "result"),
+    [
+        ("testWith365InIt", "test_with_365_in_it"),
+        ("365testWithInIt", "365_test_with_in_it"),
+        ("testWithInIt365", "test_with_in_it_365"),
+    ],
+)
+def test_digits_are_treated_as_word(test_str, result):
+    assert convert_camel_case_to_snake(test_str) == result


### PR DESCRIPTION
Fixes #442, adds two new replace rules:

- `test134` -> `test_134`
- `HTTPRequest` -> `http_request`