### PR TITLE
Fix: 293: use python represenation of enum values for default values in schema

### DIFF
--- a/ariadne/enums.py
+++ b/ariadne/enums.py
@@ -2,7 +2,16 @@ import enum
 
 from typing import Any, Dict, Optional, Union, cast
 
-from graphql.type import GraphQLEnumType, GraphQLNamedType, GraphQLSchema
+from graphql.type import (
+    GraphQLEnumType,
+    GraphQLInputField,
+    GraphQLInputObjectType,
+    GraphQLNamedType,
+    GraphQLObjectType,
+    GraphQLArgument,
+    GraphQLSchema,
+)
+from graphql.pyutils import Undefined
 
 from .types import SchemaBindable
 
@@ -18,6 +27,10 @@ class EnumType(SchemaBindable):
             self.values = values
 
     def bind_to_schema(self, schema: GraphQLSchema) -> None:
+        self.bind_to_graphql_type(schema)
+        self.bind_to_default_values(schema)
+
+    def bind_to_graphql_type(self, schema: GraphQLSchema) -> None:
         graphql_type = schema.type_map.get(self.name)
         self.validate_graphql_type(graphql_type)
         graphql_type = cast(GraphQLEnumType, graphql_type)
@@ -37,6 +50,93 @@ class EnumType(SchemaBindable):
                 "%s is defined in the schema, but it is instance of %s (expected %s)"
                 % (self.name, type(graphql_type).__name__, GraphQLEnumType.__name__)
             )
+
+    def bind_to_default_values(self, schema: GraphQLSchema) -> None:
+        for graphql_type in schema.type_map.values():
+            if isinstance(graphql_type, GraphQLInputObjectType):
+                for field_name, field in graphql_type.fields.items():
+                    self.bind_to_input_field_default_value(
+                        graphql_type, field_name, field
+                    )
+
+            if isinstance(graphql_type, GraphQLObjectType):
+                for field_name, field in graphql_type.fields.items():
+                    for arg_name, arg in field.args.items():
+                        self.bind_to_arg_default_value(
+                            graphql_type, field_name, arg_name, arg
+                        )
+
+    def bind_to_input_field_default_value(
+        self,
+        graphql_type: GraphQLInputObjectType,
+        field_name: str,
+        field: GraphQLInputField,
+    ) -> None:
+        if (
+            isinstance(field.type, GraphQLEnumType)
+            and field.type.name == self.name
+            and field.default_value is not Undefined
+        ):
+            if field.default_value not in self.values:
+                raise ValueError(
+                    "Value %s is not defined on enum %s at field %s belonging to type %s"
+                    % (
+                        field.default_value,
+                        self.name,
+                        field_name,
+                        graphql_type.name,
+                    )
+                )
+
+            field.default_value = self.values[field.default_value]
+
+    def bind_to_arg_default_value(
+        self,
+        graphql_type: GraphQLObjectType,
+        field_name: str,
+        arg_name: str,
+        arg: Union[GraphQLArgument, GraphQLInputObjectType],
+    ) -> None:
+        if isinstance(arg.type, GraphQLInputObjectType) and arg.default_value:
+            for arg_field_name, arg_field in arg.type.fields.items():
+                default_value = arg.default_value.get(arg_field_name)
+                if (
+                    isinstance(arg_field.type, GraphQLEnumType)
+                    and arg_field.type.name == self.name
+                    and default_value is not None
+                ):
+                    if default_value not in self.values:
+                        raise ValueError(
+                            "Value %s is not defined on enum %s at arg %s on field %s belonging to type %s"
+                            % (
+                                arg.default_value,
+                                self.name,
+                                arg_name,
+                                field_name,
+                                graphql_type.name,
+                            )
+                        )
+
+                    arg.default_value[arg_field_name] = self.values[default_value]
+
+        if (
+            isinstance(arg.type, GraphQLEnumType)
+            and arg.type.name == self.name
+            and arg.default_value is not None
+        ):
+            if arg.default_value not in self.values:
+                raise ValueError(
+                    "Value %s is not defined on enum %s at arg %s on field %s belonging to type %s"
+                    % (
+                        arg.default_value,
+                        self.name,
+                        arg_name,
+                        field_name,
+                        graphql_type.name,
+                    )
+                )
+
+            arg.default_value = self.values[arg.default_value]
 
 
 def set_default_enum_values_on_schema(schema: GraphQLSchema):


### PR DESCRIPTION
Fixes #293 

This PR updates `EnumType` to scan schema for fields where Enum is used for value, and default value is defined.

**TODO**

- [x] Handle fields args `field(arg: Enum = DEFAULT)`
- [x] Handle inputs fields `arg: Enum = DEFAULT`
- [x] Handle fields inputs args `field(arg: {field: DEFAULT})`
- [ ] Nested field inputs args `field(arg: {child: {field: DEFAULT}})`
- [ ] Write tests
- [ ] Cleanup the code