### PR TITLE
Add on_connect/on_disconnect hooks to ASGI app, support connection context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.14.0 (Unreleased)
+
+- Added `on_connect` and `on_disconnect` options to `ariadne.asgi.GraphQL`, enabling developers to run additional initialization and cleanup for websocket connections.
+
+
 ## 0.13.0 (2021-03-17)
 
 - Updated `graphQL-core` requirement to 3.1.3.

--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -316,6 +316,8 @@ class GraphQL:
         self,
         websocket: WebSocket,
     ):
+        await websocket.close()
+
         try:
             if self.on_disconnect:
                 result = self.on_disconnect(websocket)
@@ -325,8 +327,6 @@ class GraphQL:
             if not isinstance(error, GraphQLError):
                 error = GraphQLError(str(error), original_error=error)
             log_error(error, self.logger)
-
-        await websocket.close()
 
     async def keep_websocket_alive(self, websocket: WebSocket):
         if not self.keepalive:

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -185,10 +185,12 @@ def test_error_in_custom_websocket_on_connect_is_handled(schema):
         ws.send_json({"type": GQL_CONNECTION_INIT})
         response = ws.receive_json()
         assert response["type"] == GQL_CONNECTION_ERROR
-        assert response["payload"] == {'message': 'Unexpected error has occurred.'}
+        assert response["payload"] == {"message": "Unexpected error has occurred."}
 
 
-def test_custom_websocket_connection_error_in_custom_websocket_on_connect_is_handled(schema):
+def test_custom_websocket_connection_error_in_custom_websocket_on_connect_is_handled(
+    schema,
+):
     def on_connect(websocket, payload):
         raise WebSocketConnectionError({"msg": "Token required", "code": "auth_error"})
 

--- a/tests/asgi/test_websockets.py
+++ b/tests/asgi/test_websockets.py
@@ -1,11 +1,18 @@
+# pylint: disable=not-context-manager
+
+from starlette.testclient import TestClient
+
 from ariadne.asgi import (
-    GQL_CONNECTION_INIT,
     GQL_CONNECTION_ACK,
+    GQL_CONNECTION_ERROR,
+    GQL_CONNECTION_INIT,
+    GQL_CONNECTION_TERMINATE,
     GQL_START,
     GQL_DATA,
     GQL_STOP,
     GQL_COMPLETE,
-    GQL_CONNECTION_TERMINATE,
+    GraphQL,
+    WebSocketConnectionError,
 )
 
 
@@ -110,4 +117,134 @@ def test_stop(client):
         response = ws.receive_json()
         assert response["type"] == GQL_COMPLETE
         assert response["id"] == "test1"
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+
+def test_custom_websocket_on_connect_is_called(schema):
+    test_payload = None
+
+    def on_connect(websocket, payload):
+        assert payload == test_payload
+        websocket.scope["payload"] = payload
+
+    app = GraphQL(schema, on_connect=on_connect)
+    client = TestClient(app)
+
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+        assert ws.scope["payload"] == test_payload
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+
+def test_custom_websocket_on_connect_is_called_with_payload(schema):
+    test_payload = {"test": "ok"}
+
+    def on_connect(websocket, payload):
+        assert payload == test_payload
+        websocket.scope["payload"] = payload
+
+    app = GraphQL(schema, on_connect=on_connect)
+    client = TestClient(app)
+
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT, "payload": test_payload})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+        assert ws.scope["payload"] == test_payload
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+
+def test_custom_websocket_on_connect_is_awaited_if_its_async(schema):
+    test_payload = {"test": "ok"}
+
+    async def on_connect(websocket, payload):
+        assert payload == test_payload
+        websocket.scope["payload"] = payload
+
+    app = GraphQL(schema, on_connect=on_connect)
+    client = TestClient(app)
+
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT, "payload": test_payload})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+        assert ws.scope["payload"] == test_payload
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+
+
+def test_error_in_custom_websocket_on_connect_is_handled(schema):
+    def on_connect(websocket, payload):
+        raise ValueError("Oh No!")
+
+    app = GraphQL(schema, on_connect=on_connect)
+    client = TestClient(app)
+
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ERROR
+        assert response["payload"] == {'message': 'Unexpected error has occurred.'}
+
+
+def test_custom_websocket_connection_error_in_custom_websocket_on_connect_is_handled(schema):
+    def on_connect(websocket, payload):
+        raise WebSocketConnectionError({"msg": "Token required", "code": "auth_error"})
+
+    app = GraphQL(schema, on_connect=on_connect)
+    client = TestClient(app)
+
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ERROR
+        assert response["payload"] == {"msg": "Token required", "code": "auth_error"}
+
+
+def test_custom_websocket_on_disconnect_is_called(schema):
+    def on_disconnect(websocket):
+        websocket.scope["on_disconnect"] = True
+
+    app = GraphQL(schema, on_disconnect=on_disconnect)
+    client = TestClient(app)
+
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+        assert "on_disconnect" not in ws.scope
+
+    assert ws.scope["on_disconnect"] is True
+
+
+def test_custom_websocket_on_disconnect_is_awaited_if_its_async(schema):
+    async def on_disconnect(websocket):
+        websocket.scope["on_disconnect"] = True
+
+    app = GraphQL(schema, on_disconnect=on_disconnect)
+    client = TestClient(app)
+
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
+        ws.send_json({"type": GQL_CONNECTION_TERMINATE})
+        assert "on_disconnect" not in ws.scope
+
+    assert ws.scope["on_disconnect"] is True
+
+
+def test_error_in_custom_websocket_on_disconnect_is_handled(schema):
+    async def on_disconnect(websocket):
+        raise ValueError("Oh No!")
+
+    app = GraphQL(schema, on_disconnect=on_disconnect)
+    client = TestClient(app)
+
+    with client.websocket_connect("/", "graphql-ws") as ws:
+        ws.send_json({"type": GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GQL_CONNECTION_ACK
         ws.send_json({"type": GQL_CONNECTION_TERMINATE})


### PR DESCRIPTION
Adds `on_connect` and `on_disconnect` options to ASGI GraphQL app and introduces connection context.

# `on_connect`

`on_connect` is optional callable that is called when GraphQL client opens WebSocket connection with the server. It's called with two arguments: `WebSocket` instance and `Any` value with connection payload. It can be used to extract supported data from connection's payload to the current scope:

```python
def on_connect(ws: WebSocket, payload: Any):
    if not isinstance(payload, dict):
        return

    ws.scope["auth"] = get_user_from_token(payload.get("auth_token"))


def get_context_value(request):
    if request.scope.type == "websocket":
        return {"auth": request.scope["auth"]}
    
    return {"auth": get_user_from_token(request.headers.get("authorization")}
```

As bonus, users may raise new `WebSocketConnectionError` from `on_connect` to get nice error masse sent to client:

```python
from ariadne.asgi import WebSocketConnectionError


def on_connect(ws: WebSocket, payload: Any):
    if not isinstance(payload, dict):
        raise WebSocketConnectionError({"message": "payload object is required", "code": "payload.value_error"})

    ws.scope["auth"] = get_user_from_token(payload.get("auth_token"))
```

# `on_disconnect`

`on_disconnect` is optional callable that is called when GraphQL client closes websocket connection. Receives one argument: `WebSocket` instance.

```python
def on_disconnect(ws):
    # get some data from WS scope and maybe log it somewhere or set user from `ws.scope` to offline?
```


Supersedes #406, #403 and #355.