### PR TITLE
Fix #478: Update links to point to GitHub discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 Spectrum
+  - name: 💬 GitHub Discussions
     url: https://spectrum.chat/ariadne
-    about: If you have a question about library usage, "how to", GraphQL or just want to share the love, please use our Spectrum.
+    about: If you have a question about library usage, "how to", GraphQL or just want to share the love, please use GitHub discussions instead.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For more guides and examples, please see the [documentation](https://ariadnegrap
 Contributing
 ------------
 
-We are welcoming contributions to Ariadne! If you've found a bug or issue, feel free to use [GitHub issues](https://github.com/mirumee/ariadne/issues). If you have any questions or feedback, don't hesitate to catch us on [Spectrum](https://spectrum.chat/ariadne).
+We are welcoming contributions to Ariadne! If you've found a bug or issue, feel free to use [GitHub issues](https://github.com/mirumee/ariadne/issues). If you have any questions or feedback, don't hesitate to catch us on [GitHub discussions](https://github.com/mirumee/ariadne/discussions/).
 
 For guidance and instructions, please see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,0 @@
-build:
-    image: latest
-
-python:
-    version: 3.6


### PR DESCRIPTION
GitHub bought Spectrum some time ago and is currently [sunsetting it](https://spectrum.chat/spectrum/general/join-us-on-our-new-journey~e4ca0386-f15c-4ba8-8184-21cf5fa39cf5) in favor of GH discussions.

I'm not biggest fan of how those are looking like now, but I'm finding them much less quirky to use than Spectrum, and, on flip side, we can easily convert issues to those without extra burden on original poster.

This PR also nukes extra erad the docs config file as we don't use those anymore.

Fixes #478

I'll open next PR on `ariadne-website` repo.