### PR TITLE
Remove superfluous schema validation

### DIFF
--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -5,7 +5,6 @@ from graphql import (
     assert_valid_schema,
     build_ast_schema,
     parse,
-    validate_schema,
 )
 
 from .enums import set_default_enum_values_on_schema
@@ -23,7 +22,6 @@ def make_executable_schema(
 
     ast_document = parse(type_defs)
     schema = build_ast_schema(ast_document)
-    validate_schema(schema)
 
     for bindable in bindables:
         if isinstance(bindable, list):


### PR DESCRIPTION
It turns out that  `validate_schema` called in https://github.com/mirumee/ariadne/blob/master/ariadne/executable_schema.py#L26 is not needed here. 
In the other hand, `assert_validate_schema` is called here: https://github.com/mirumee/ariadne/blob/master/ariadne/executable_schema.py#L40 which is sufficient. 

Fixes #523 