### PR TITLE
Added option to trace default resolvers as well

### DIFF
--- a/ariadne/contrib/tracing/apollotracing.py
+++ b/ariadne/contrib/tracing/apollotracing.py
@@ -23,7 +23,8 @@ TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 
 
 class ApolloTracingExtension(Extension):
-    def __init__(self):
+    def __init__(self, trace_default_resolver: bool = False):
+        self.trace_default_resolver = trace_default_resolver
         self.start_date = None
         self.start_timestamp = None
         self.resolvers = []
@@ -37,7 +38,7 @@ class ApolloTracingExtension(Extension):
     async def resolve(
         self, next_: Resolver, parent: Any, info: GraphQLResolveInfo, **kwargs
     ):
-        if not should_trace(info):
+        if not should_trace(info, self.trace_default_resolver):
             result = next_(parent, info, **kwargs)
             if isawaitable(result):
                 result = await result

--- a/ariadne/contrib/tracing/utils.py
+++ b/ariadne/contrib/tracing/utils.py
@@ -16,9 +16,10 @@ def should_trace(info: GraphQLResolveInfo, trace_default_resolver: bool = False)
         return False
 
     resolver = info.parent_type.fields[info.field_name].resolve
-    default_resolver_bool = is_default_resolver(resolver)
-    if trace_default_resolver and default_resolver_bool:
+    if trace_default_resolver:
         default_resolver_bool = False
+    else:
+        default_resolver_bool = is_default_resolver(resolver)
     return not (default_resolver_bool or is_introspection_field(info))
 
 

--- a/ariadne/contrib/tracing/utils.py
+++ b/ariadne/contrib/tracing/utils.py
@@ -11,16 +11,15 @@ def format_path(path: ResponsePath):
     return elements[::-1]
 
 
-def should_trace(info: GraphQLResolveInfo):
+def should_trace(info: GraphQLResolveInfo, trace_default_resolver: bool = False):
     if info.field_name not in info.parent_type.fields:
         return False
 
     resolver = info.parent_type.fields[info.field_name].resolve
-    return not (
-        resolver is None
-        or is_default_resolver(resolver)
-        or is_introspection_field(info)
-    )
+    default_resolver_bool = is_default_resolver(resolver)
+    if trace_default_resolver and default_resolver_bool:
+        default_resolver_bool = False
+    return not (default_resolver_bool or is_introspection_field(info))
 
 
 def is_introspection_field(info: GraphQLResolveInfo):

--- a/ariadne/resolvers.py
+++ b/ariadne/resolvers.py
@@ -61,6 +61,6 @@ def resolve_to(field_name: str) -> Resolver:
 
 def is_default_resolver(resolver: Resolver) -> bool:
     # pylint: disable=comparison-with-callable
-    if resolver == default_field_resolver:
+    if resolver == default_field_resolver or not resolver:
         return True
     return hasattr(resolver, "_ariadne_alias_resolver")

--- a/tests/tracing/test_utils.py
+++ b/tests/tracing/test_utils.py
@@ -48,7 +48,7 @@ def test_introspection_field_is_excluded_from_tracing():
     assert not should_trace(info)
 
 
-def test_field_with_default_resolver_is_excluded_from_tracing():
+def test_field_with_default_resolver_is_excluded_from_tracing_by_default():
     path = Mock(key="name", prev=Mock(key="user", prev=None))
     info = Mock(
         field_name="name",
@@ -56,6 +56,16 @@ def test_field_with_default_resolver_is_excluded_from_tracing():
         parent_type=Mock(fields={"name": Mock(resolve=None)}),
     )
     assert not should_trace(info)
+
+
+def test_field_with_default_resolver_is_included_in_tracing_when_set():
+    path = Mock(key="name", prev=Mock(key="user", prev=None))
+    info = Mock(
+        field_name="name",
+        path=path,
+        parent_type=Mock(fields={"name": Mock(resolve=None)}),
+    )
+    assert should_trace(info, trace_default_resolver=True)
 
 
 def test_field_with_custom_resolver_is_included_in_tracing():


### PR DESCRIPTION
Adding the option to trace default resolvers if someone want. This is actually very useful in tracing base field types for which resolvers are not explicitly set because those can be use in apollo studio to see which fields are being accessed and how much thereby helping api lifecycle management