### PR TITLE
Fix pylint warning

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -256,8 +256,8 @@ class GraphQL:
         except WebSocketDisconnect:
             pass
         finally:
-            for operation_id in subscriptions:
-                await subscriptions[operation_id].aclose()
+            for subscription in subscriptions.values():
+                await subscription.aclose()
 
     async def handle_websocket_message(
         self,


### PR DESCRIPTION
Fixes pylint warning complaining that we are iterating on subscription keys to modify dict's values, eg:

```python
for key in some_dict:
    some_dict[key].do_smth()
```

Where we could do:

```python
for value in some_dict.values():
    value.do_smth()
```