### PR TITLE
Added convert_kwargs_to_snake_case_middleware

### DIFF
--- a/ariadne/middleware.py
+++ b/ariadne/middleware.py
@@ -1,0 +1,17 @@
+from typing import Callable
+
+from graphql import GraphQLResolveInfo
+
+from .utils import convert_kwargs_to_snake_case
+
+
+def convert_kwargs_to_snake_case_middleware(resolver: Callable, *args, **kwargs):
+    """Convert all kwargs to snake case."""
+    info: GraphQLResolveInfo = args[1]
+    is_introspection_query = "__schema" in info.path.as_list()
+
+    # Introspection query resolvers use camelCase variables so if you would convert
+    # those as well a TypeError would be raised.
+    if is_introspection_query:
+        return resolver(*args, **kwargs)
+    return convert_kwargs_to_snake_case(resolver)(*args, **kwargs)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,18 @@
+from unittest.mock import MagicMock
+
+from ariadne.middleware import convert_kwargs_to_snake_case_middleware
+
+
+def test_kwargs_converted_to_snake_case():
+    resolver, parent, info = MagicMock(), None, MagicMock()
+    kwargs = {"convertThisPlease": None}
+    convert_kwargs_to_snake_case_middleware(resolver, parent, info, **kwargs)
+    resolver.assert_called_once_with(parent, info, convert_this_please=None)
+
+
+def test_kwargs_not_converted_to_snake_case_if_introspection_query():
+    resolver, parent, info = MagicMock(), None, MagicMock()
+    info.path.as_list = MagicMock(return_value=["__schema"])
+    kwargs = {"convertThisPlease": None}
+    convert_kwargs_to_snake_case_middleware(resolver, parent, info, **kwargs)
+    resolver.assert_called_once_with(parent, info, **kwargs)


### PR DESCRIPTION
This pull request adds a simple middleware, that applies the convert_kwargs_to_snake_case decorator to all resolvers.