### PR TITLE
Add execution context class propagation to GraphQL

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -10,10 +10,11 @@ from typing import (
     Optional,
     Union,
     cast,
+    Type,
 )
 
 from graphql import GraphQLError, GraphQLSchema
-from graphql.execution import Middleware, MiddlewareManager
+from graphql.execution import Middleware, MiddlewareManager, ExecutionContext
 from starlette.datastructures import UploadFile
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
@@ -89,6 +90,7 @@ class GraphQL:
         extensions: Optional[Extensions] = None,
         middleware: Optional[Middlewares] = None,
         keepalive: float = None,
+        execution_context_class: Optional[Type[ExecutionContext]] = None,
     ):
         self.context_value = context_value
         self.root_value = root_value
@@ -103,6 +105,7 @@ class GraphQL:
         self.middleware = middleware
         self.keepalive = keepalive
         self.schema = schema
+        self.execution_context_class = execution_context_class
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):
         if scope["type"] == "http":
@@ -189,6 +192,7 @@ class GraphQL:
             error_formatter=self.error_formatter,
             extensions=extensions,
             middleware=middleware,
+            execution_context_class=self.execution_context_class,
         )
         status_code = 200 if success else 400
         return JSONResponse(response, status_code=status_code)

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -46,6 +46,7 @@ async def graphql(
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
     extensions: ExtensionList = None,
+    execution_context_class: Optional[Type[ExecutionContext]] = None,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions, context_value)
@@ -91,7 +92,7 @@ async def graphql(
                 context_value=context_value,
                 variable_values=variables,
                 operation_name=operation_name,
-                execution_context_class=ExecutionContext,
+                execution_context_class=execution_context_class,
                 middleware=extension_manager.as_middleware_manager(middleware),
                 **kwargs,
             )
@@ -129,6 +130,7 @@ def graphql_sync(
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
     extensions: ExtensionList = None,
+    execution_context_class: Optional[Type[ExecutionContext]] = None,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions, context_value)
@@ -178,7 +180,7 @@ def graphql_sync(
                 context_value=context_value,
                 variable_values=variables,
                 operation_name=operation_name,
-                execution_context_class=ExecutionContext,
+                execution_context_class=execution_context_class,
                 middleware=extension_manager.as_middleware_manager(middleware),
                 **kwargs,
             )

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -1,8 +1,8 @@
 import json
 from cgi import FieldStorage
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, List, Optional, Union, Type
 
-from graphql import GraphQLError, GraphQLSchema
+from graphql import GraphQLError, GraphQLSchema, ExecutionContext
 from graphql.execution import Middleware, MiddlewareManager
 
 from .constants import (
@@ -51,6 +51,7 @@ class GraphQL:
         error_formatter: ErrorFormatter = format_error,
         extensions: Optional[Extensions] = None,
         middleware: Optional[Middlewares] = None,
+        execution_context_class: Optional[Type[ExecutionContext]] = None,
     ) -> None:
         self.context_value = context_value
         self.root_value = root_value
@@ -62,6 +63,7 @@ class GraphQL:
         self.extensions = extensions
         self.middleware = middleware
         self.schema = schema
+        self.execution_context_class = execution_context_class
 
     def __call__(self, environ: dict, start_response: Callable) -> List[bytes]:
         try:
@@ -188,6 +190,7 @@ class GraphQL:
             error_formatter=self.error_formatter,
             extensions=extensions,
             middleware=middleware,
+            execution_context_class=self.execution_context_class,
         )
 
     def get_context_for_request(self, environ: dict) -> Optional[ContextValue]:


### PR DESCRIPTION
Propagates `execution_context_class` to `graphql.graphql` call from `ariadne.graphql_sync` and `ariadne.graphql`. Also adds appropriate constructor parameters for both WSGI and ASGI apps.

The original intention is to have ability to override default field resolver. I think, it could be useful in other ways as well.