### PR TITLE
Add ability to override `graphql` arguments from ASGI and WSGI apps

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -89,6 +89,7 @@ class GraphQL:
         extensions: Optional[Extensions] = None,
         middleware: Optional[Middlewares] = None,
         keepalive: float = None,
+        **graphql_kwargs: Any,
     ):
         self.context_value = context_value
         self.root_value = root_value
@@ -103,6 +104,7 @@ class GraphQL:
         self.middleware = middleware
         self.keepalive = keepalive
         self.schema = schema
+        self.graphql_kwargs = graphql_kwargs
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):
         if scope["type"] == "http":
@@ -189,6 +191,7 @@ class GraphQL:
             error_formatter=self.error_formatter,
             extensions=extensions,
             middleware=middleware,
+            **self.graphql_kwargs,
         )
         status_code = 200 if success else 400
         return JSONResponse(response, status_code=status_code)
@@ -357,6 +360,7 @@ class GraphQL:
             introspection=self.introspection,
             logger=self.logger,
             error_formatter=self.error_formatter,
+            **self.graphql_kwargs,
         )
         if not success:
             results = cast(List[dict], results)

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -46,6 +46,7 @@ async def graphql(
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
     extensions: ExtensionList = None,
+    execution_context_class: Optional[Type[ExecutionContext]] = ExecutionContext,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions, context_value)
@@ -91,7 +92,7 @@ async def graphql(
                 context_value=context_value,
                 variable_values=variables,
                 operation_name=operation_name,
-                execution_context_class=ExecutionContext,
+                execution_context_class=execution_context_class,
                 middleware=extension_manager.as_middleware_manager(middleware),
                 **kwargs,
             )
@@ -129,6 +130,7 @@ def graphql_sync(
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
     extensions: ExtensionList = None,
+    execution_context_class: Optional[Type[ExecutionContext]] = ExecutionContext,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions, context_value)
@@ -178,7 +180,7 @@ def graphql_sync(
                 context_value=context_value,
                 variable_values=variables,
                 operation_name=operation_name,
-                execution_context_class=ExecutionContext,
+                execution_context_class=execution_context_class,
                 middleware=extension_manager.as_middleware_manager(middleware),
                 **kwargs,
             )

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -51,6 +51,7 @@ class GraphQL:
         error_formatter: ErrorFormatter = format_error,
         extensions: Optional[Extensions] = None,
         middleware: Optional[Middlewares] = None,
+        **graphql_kwargs: Any,
     ) -> None:
         self.context_value = context_value
         self.root_value = root_value
@@ -62,6 +63,7 @@ class GraphQL:
         self.extensions = extensions
         self.middleware = middleware
         self.schema = schema
+        self.graphql_kwargs = graphql_kwargs
 
     def __call__(self, environ: dict, start_response: Callable) -> List[bytes]:
         try:
@@ -188,6 +190,7 @@ class GraphQL:
             error_formatter=self.error_formatter,
             extensions=extensions,
             middleware=middleware,
+            **self.graphql_kwargs,
         )
 
     def get_context_for_request(self, environ: dict) -> Optional[ContextValue]:


### PR DESCRIPTION
Add ability to override `graphql` arguments from ASGI and WSGI apps
and remove hard-coded `execution_context_class` from `ariadne.graphql.graphql`
and `ariadne.graphql.graphql_sync` functions.

The motivation for this change is to give a user ability to customize
GraphQL behaviour in various ways. As an example user can override error
handling mechanism completely via custom `execution_context_class` or
pass custom field resolver etc.