### PR TITLE
RFC: Configurable JSON response class

### DIFF
--- a/ariadne/asgi.py
+++ b/ariadne/asgi.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Type,
     Union,
     cast,
 )
@@ -89,6 +90,7 @@ class GraphQL:
         extensions: Optional[Extensions] = None,
         middleware: Optional[Middlewares] = None,
         keepalive: float = None,
+        json_response_class: Type[JSONResponse] = JSONResponse,
     ):
         self.context_value = context_value
         self.root_value = root_value
@@ -103,6 +105,7 @@ class GraphQL:
         self.middleware = middleware
         self.keepalive = keepalive
         self.schema = schema
+        self.json_response_class = json_response_class
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send):
         if scope["type"] == "http":
@@ -191,7 +194,7 @@ class GraphQL:
             middleware=middleware,
         )
         status_code = 200 if success else 400
-        return JSONResponse(response, status_code=status_code)
+        return self.json_response_class(response, status_code=status_code)
 
     async def extract_data_from_request(self, request: Request):
         content_type = request.headers.get("Content-Type", "")

--- a/tests/asgi/test_custom_json_response.py
+++ b/tests/asgi/test_custom_json_response.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any
+from typing import Any, Dict, Type
 
 import pytest
 from starlette.responses import JSONResponse
@@ -23,7 +23,15 @@ class PrettyJSONResponse(JSONResponse):
 
 @pytest.fixture
 def app(schema):
-    return GraphQL(schema, json_response_class=PrettyJSONResponse)
+    class CustomGraphQL(GraphQL):
+        def build_json_response(
+            self,
+            content: Dict[str, Any],
+            status_code: int
+        ) -> Type[JSONResponse]:
+            return PrettyJSONResponse(content, status_code=status_code)
+    
+    return CustomGraphQL(schema)
 
 
 def test_custom_json_response(client):

--- a/tests/asgi/test_custom_json_response.py
+++ b/tests/asgi/test_custom_json_response.py
@@ -1,0 +1,40 @@
+import json
+from typing import Any
+
+import pytest
+from starlette.responses import JSONResponse
+
+from ariadne.asgi import GraphQL
+
+
+operation_name = "SayHello"
+variables = {"name": "Bob"}
+complex_query = """
+  query SayHello($name: String!) {
+    hello(name: $name)
+  }
+"""
+
+
+class PrettyJSONResponse(JSONResponse):
+    def render(self, content: Any) -> bytes:
+        return json.dumps(content, indent=4).encode("utf-8")
+
+
+@pytest.fixture
+def app(schema):
+    return GraphQL(schema, json_response_class=PrettyJSONResponse)
+
+
+def test_custom_json_response(client):
+    response = client.post(
+        "/",
+        json={
+            "query": complex_query,
+            "variables": variables,
+            "operationName": operation_name,
+        },
+    )
+
+    expected_json = {"data": {"hello": "Hello, Bob!"}}
+    assert response.text == json.dumps(expected_json, indent=4)


### PR DESCRIPTION
## Context

We are working on a FastAPI app that uses Ariadne's ASGI server for its GraphQL endpoints. We are using `ORJSONResponse` throughout that app and would like to be able to use the same response class for our GraphQL requests. Performance is definitely a big motivator for this, but we also want to ensure that response formats are consistent throughout the API, and using the same JSON serializer throughout is a good step in that direction.

## Changes

This PR adds a `json_response_class` parameter to `ariadne.asgi.GraphQL.__init__` that may be any class inheriting from `starlette.responses.JSONResponse` defaults to that class. This value of this argument is then used as the response class in `GraphQL.graphql_http_server`.

I took a look at the websocket handlers in that class and did not see any place where this change should apply, but I missed something I'm certainly happy to correct it. If this changes ends up being accepted, I'm also happy to put in an equivalent PR on `ariadne-website` to update the docs.