### PR TITLE
Fix query cost calculation multiplier handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Made `Query` type optional in federated schemas.
 - Updated default resolvers to test for `Mapping` instead of `dict`.
 - Removed `ariadne.contrib.django`. (Use [ariadne_django](https://github.com/reset-button/ariadne_django) instead).
+- Updated query cost validator to handle optional variables.
 
 
 ## 0.13.0 (2021-03-17)

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -281,12 +281,15 @@ class CostValidator(ValidationRule):
             val = field_args
             for key in accessor:
                 val = val.get(key)
-            multipliers.append(val)
+            try:
+                multipliers.append(int(val))
+            except (ValueError, TypeError):
+                pass
         multipliers = [
             len(multiplier) if isinstance(multiplier, (list, tuple)) else multiplier
             for multiplier in multipliers
         ]
-        return [m for m in multipliers if m != 0]
+        return [m for m in multipliers if m > 0]
 
     def get_cost_exceeded_error(self) -> GraphQLError:
         return GraphQLError(

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -285,11 +285,11 @@ class CostValidator(ValidationRule):
                 multipliers.append(int(val))  # type: ignore
             except (ValueError, TypeError):
                 pass
-        multipliers: List[int] = [
+        multipliers = [
             len(multiplier) if isinstance(multiplier, (list, tuple)) else multiplier
             for multiplier in multipliers
         ]
-        return [m for m in multipliers if m > 0]
+        return [m for m in multipliers if m > 0]  # type: ignore
 
     def get_cost_exceeded_error(self) -> GraphQLError:
         return GraphQLError(

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -282,10 +282,10 @@ class CostValidator(ValidationRule):
             for key in accessor:
                 val = val.get(key)
             try:
-                multipliers.append(int(val))
+                multipliers.append(int(val))  # type: ignore
             except (ValueError, TypeError):
                 pass
-        multipliers = [
+        multipliers: List[int] = [
             len(multiplier) if isinstance(multiplier, (list, tuple)) else multiplier
             for multiplier in multipliers
         ]

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -318,9 +318,7 @@ def test_complex_field_cost_multiplication_by_values_from_literals_handles_nulls
 ):
     query = "{ complex(valueA: 5, valueB: null) }"
     ast = parse(query)
-    rule = cost_validator(
-        maximum_cost=3, cost_map=cost_map
-    )
+    rule = cost_validator(maximum_cost=3, cost_map=cost_map)
     result = validate(schema, ast, [rule])
     assert result == [
         GraphQLError(
@@ -339,9 +337,7 @@ def test_complex_field_cost_multiplication_by_values_from_variables_handles_opti
         }
     """
     ast = parse(query)
-    rule = cost_validator(
-        maximum_cost=3, variables={"valueA": 5}, cost_map=cost_map
-    )
+    rule = cost_validator(maximum_cost=3, variables={"valueA": 5}, cost_map=cost_map)
     result = validate(schema, ast, [rule])
     assert result == [
         GraphQLError(
@@ -356,9 +352,7 @@ def test_complex_field_cost_multiplication_by_values_from_literals_handles_optio
 ):
     query = "{ complex(valueA: 5) }"
     ast = parse(query)
-    rule = cost_validator(
-        maximum_cost=3, cost_map=cost_map
-    )
+    rule = cost_validator(maximum_cost=3, cost_map=cost_map)
     result = validate(schema, ast, [rule])
     assert result == [
         GraphQLError(


### PR DESCRIPTION
Fixes `multipliers` option handling in query cost calculation, so when value specified in multipliers is not set (because its optional), it's treated as `0` instead of validator raising error on `None` not being addable to `0`.

Fixes #716 