### PR TITLE
Fix install dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=["ariadne"],
     include_package_data=True,
     install_requires=[
-        "graphql-core>=3.1.0",
+        "graphql-core>=3.1.0,<3.2",
         "starlette<0.18",
         "typing_extensions>=3.6.0",
     ],


### PR DESCRIPTION
The current version of ariadne is not compatible with [`graphql-core 3.2`](https://github.com/graphql-python/graphql-core/releases/tag/v3.2.0), hence we need to pin the dependencies to `graphql-core<3.2`

Related to https://github.com/mirumee/ariadne/issues/769