### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
         pytest --cov=ariadne --cov=tests
     - uses: codecov/codecov-action@v1
     - name: Linters
-      if: ${{ matrix.python-version != 3.6 }}
       run: |
         pylint ariadne tests setup.py
         mypy ariadne --ignore-missing-imports

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.15.0 (unreleased)
 
+- Drop Python 3.6 support.
 - Added basic support for `OPTIONS` HTTP request.
 - Refactor `ariadne.asgi.GraphQL` to make it easier to customize JSON response.
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ CLASSIFIERS = [
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Removes unsupported Python version from test grid and packages manifest.