### PR TITLE
Federated graph regex performance. 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request_target:
-    branches:
-      - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request_target:
+    branches:
+      - master
 
 jobs:
   build:
@@ -16,7 +18,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:

--- a/ariadne/contrib/federation/utils.py
+++ b/ariadne/contrib/federation/utils.py
@@ -14,17 +14,17 @@ from graphql.type import (
 )
 
 
-_i_token_delimiter = r"(?:^|[\s\r\n]+|$)"
+_i_token_delimiter = r"(?:^|[\s]+|$)"
 _i_token_name = "[_A-Za-z][_0-9A-Za-z]*"
 _i_token_arguments = r"\([^)]*\)"
 _i_token_location = "[_A-Za-z][_0-9A-Za-z]*"
-_i_token_description_block_string = r"(?:^\s*\"{3}(?:[^\"]|[\s])*?\"{3}\s*$)"
-_i_token_description_single_line = r"(?:^\s*\"(?:[^\"\n\r])*?\"\s*$)"
+_i_token_description_block_string = r"(?:\"{3}(?:[^\"]{1,}|[\s])\"{3})"
+_i_token_description_single_line = r"(?:\"(?:[^\"\n\r])*?\")"
 
 _r_directive_definition = re.compile(
     "("
     f"{_i_token_delimiter}"
-    f"(?:{_i_token_description_block_string}|{_i_token_description_single_line})"
+    f"(?:{_i_token_description_block_string}|{_i_token_description_single_line})??"
     f"{_i_token_delimiter}directive"
     f"(?:{_i_token_delimiter})?@({_i_token_name})"
     f"(?:(?:{_i_token_delimiter})?{_i_token_arguments})?"


### PR DESCRIPTION
The main performance problem comes from `(?:\"{3}(?:[^\"]|[\s])*?\"{3})`.

The lazy '*?' drastically kills the performance of any federated graph that uses block comments, even if that graph is valid and has no custom directives.

Additionally, the old solution creates a run away regex with something like this: (4 quotes)
```
        """"
        Any Description
        """
        directive @custom on FIELD
        
        type Query {
            rootField: String @custom
        }
```

New solution will just ignore this comment.
```
        """"
        Any Description
        """
        
        type Query {
            rootField: String @custom
        }
```