### PR TITLE
Feature: Basic Federation 2 Support

### DIFF
--- a/ariadne/contrib/federation/schema.py
+++ b/ariadne/contrib/federation/schema.py
@@ -35,7 +35,7 @@ base_federation_service_type_defs = """
 # fed 1 typedefs; only @key differs from the rest
 federation_one_service_type_defs = """
     directive @key(fields: String!) repeatable on OBJECT | INTERFACE
-""" 
+"""
 
 # fed 2 typedefs; adds the new directives, although they are gateway-driven, not subgraph-driven
 federation_two_service_type_defs = """
@@ -79,11 +79,15 @@ def make_federated_schema(
     # NOTE: This does NOT interfere with ariadne's directives support.
     sdl = purge_schema_directives(type_defs)
     type_token = "extend type" if has_query_type(sdl) else "type"
-    federation_service_type = base_federation_service_type_defs.format(type_token=type_token)
+    federation_service_type = base_federation_service_type_defs.format(
+        type_token=type_token
+    )
 
     tdl = [type_defs, federation_service_type]
 
-    link = re.search(r"@link.*\(.*url:.*?\"(.*?)\"[^)]+\)", sdl, re.MULTILINE | re.DOTALL) # use regex to parse if it's fed 1 or fed 2; adds dedicated typedefs per spec
+    link = re.search(
+        r"@link.*\(.*url:.*?\"(.*?)\"[^)]+\)", sdl, re.MULTILINE | re.DOTALL
+    )  # use regex to parse if it's fed 1 or fed 2; adds dedicated typedefs per spec
     if link and link.group(1) == "https://specs.apollo.dev/federation/v2.0":
         tdl.append(federation_two_service_type_defs)
     else:

--- a/ariadne/contrib/federation/schema.py
+++ b/ariadne/contrib/federation/schema.py
@@ -86,7 +86,7 @@ def make_federated_schema(
     tdl = [type_defs, federation_service_type]
 
     link = re.search(
-        r"@link.*\(.*url:.*?\"(.*?)\"[^)]+\)", sdl, re.MULTILINE | re.DOTALL
+        r"@link\s*\(\s*url:\s*\"(.*?)\"[^)]+\)", sdl, re.MULTILINE | re.DOTALL 
     )  # use regex to parse if it's fed 1 or fed 2; adds dedicated typedefs per spec
     if link and link.group(1) == "https://specs.apollo.dev/federation/v2.0":
         tdl.append(federation_two_service_type_defs)

--- a/ariadne/contrib/federation/schema.py
+++ b/ariadne/contrib/federation/schema.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, List, Type, Union, cast
 
 from graphql import extend_schema, parse
@@ -14,8 +15,7 @@ from ...schema_visitor import SchemaDirectiveVisitor
 from ...types import SchemaBindable
 from .utils import get_entity_types, purge_schema_directives, resolve_entities
 
-
-federation_service_type_defs = """
+base_federation_service_type_defs = """
     scalar _Any
 
     type _Service {{
@@ -27,10 +27,24 @@ federation_service_type_defs = """
     }}
 
     directive @external on FIELD_DEFINITION
-    directive @requires(fields: String!) on FIELD_DEFINITION
-    directive @provides(fields: String!) on FIELD_DEFINITION
+	directive @requires(fields: String!) on FIELD_DEFINITION
+	directive @provides(fields: String!) on FIELD_DEFINITION
+	directive @extends on OBJECT | INTERFACE
+"""
+
+# fed 1 typedefs; only @key differs from the rest
+federation_one_service_type_defs = """
     directive @key(fields: String!) repeatable on OBJECT | INTERFACE
-    directive @extends on OBJECT | INTERFACE
+""" 
+
+# fed 2 typedefs; adds the new directives, although they are gateway-driven, not subgraph-driven
+federation_two_service_type_defs = """
+    directive @key(fields: String!, resolvable: Boolean) repeatable on OBJECT | INTERFACE
+	directive @link(import: [String!], url: String!) repeatable on SCHEMA
+	directive @shareable on OBJECT | FIELD_DEFINITION
+    directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+	directive @override(from: String!) on FIELD_DEFINITION
+	directive @inaccessible on SCALAR | OBJECT | FIELD_DEFINITION | ARGUMENT_DEFINITION | INTERFACE | UNION | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
 """
 
 federation_entity_type_defs = """
@@ -65,9 +79,17 @@ def make_federated_schema(
     # NOTE: This does NOT interfere with ariadne's directives support.
     sdl = purge_schema_directives(type_defs)
     type_token = "extend type" if has_query_type(sdl) else "type"
-    federation_service_type = federation_service_type_defs.format(type_token=type_token)
+    federation_service_type = base_federation_service_type_defs.format(type_token=type_token)
 
-    type_defs = join_type_defs([type_defs, federation_service_type])
+    tdl = [type_defs, federation_service_type]
+
+    link = re.search(r"@link.*\(.*url:.*?\"(.*?)\"[^)]+\)", sdl, re.MULTILINE | re.DOTALL) # use regex to parse if it's fed 1 or fed 2; adds dedicated typedefs per spec
+    if link and link.group(1) == "https://specs.apollo.dev/federation/v2.0":
+        tdl.append(federation_two_service_type_defs)
+    else:
+        tdl.append(federation_one_service_type_defs)
+
+    type_defs = join_type_defs(tdl)
     schema = make_executable_schema(
         type_defs,
         *bindables,

--- a/ariadne/contrib/federation/schema.py
+++ b/ariadne/contrib/federation/schema.py
@@ -86,7 +86,7 @@ def make_federated_schema(
     tdl = [type_defs, federation_service_type]
 
     link = re.search(
-        r"@link\s*\(\s*url:\s*\"(.*?)\"[^)]+\)", sdl, re.MULTILINE | re.DOTALL 
+        r"@link\s*\(\s*url:\s*\"(.*?)\"[^)]+\)", sdl, re.MULTILINE | re.DOTALL
     )  # use regex to parse if it's fed 1 or fed 2; adds dedicated typedefs per spec
     if link and link.group(1) == "https://specs.apollo.dev/federation/v2.0":
         tdl.append(federation_two_service_type_defs)

--- a/ariadne/contrib/federation/schema.py
+++ b/ariadne/contrib/federation/schema.py
@@ -86,7 +86,7 @@ def make_federated_schema(
     tdl = [type_defs, federation_service_type]
 
     link = re.search(
-        r"@link\s*\(\s*url:\s*\"(.*?)\"[^)]+\)", sdl, re.MULTILINE | re.DOTALL
+        r"(?<=@link).*?url:.*?\"(.*?)\".?[^)]+?", sdl, re.MULTILINE | re.DOTALL
     )  # use regex to parse if it's fed 1 or fed 2; adds dedicated typedefs per spec
     if link and link.group(1) == "https://specs.apollo.dev/federation/v2.0":
         tdl.append(federation_two_service_type_defs)

--- a/ariadne/contrib/federation/utils.py
+++ b/ariadne/contrib/federation/utils.py
@@ -56,7 +56,7 @@ _allowed_directives = [
     "shareable",  # Federation 2 directive.
     "tag",  # Federation 2 directive.
     "override",  # Federation 2 directive.
-    "inaccessible", # Federation 2 directive.
+    "inaccessible",  # Federation 2 directive.
 ]
 
 

--- a/ariadne/contrib/federation/utils.py
+++ b/ariadne/contrib/federation/utils.py
@@ -52,6 +52,11 @@ _allowed_directives = [
     "provides",  # Federation directive.
     "key",  # Federation directive.
     "extends",  # Federation directive.
+    "link",  # Federation 2 directive.
+    "shareable",  # Federation 2 directive.
+    "tag",  # Federation 2 directive.
+    "override",  # Federation 2 directive.
+    "inaccessible", # Federation 2 directive.
 ]
 
 

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -838,7 +838,7 @@ def test_federated_schema_without_query_is_valid():
     assert sic(result.data["_service"]["sdl"]) == sic(type_defs)
 
 
-def test_federated_schema_version_detected():
+def test_federation_2_0_version_is_detected_in_schema():
     type_defs = """
         extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override"]) 
 

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -837,6 +837,7 @@ def test_federated_schema_without_query_is_valid():
     assert result.errors is None
     assert sic(result.data["_service"]["sdl"]) == sic(type_defs)
 
+
 def test_federated_schema_version_detected():
     type_defs = """
         extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override"]) 

--- a/tests/federation/test_schema.py
+++ b/tests/federation/test_schema.py
@@ -836,3 +836,36 @@ def test_federated_schema_without_query_is_valid():
 
     assert result.errors is None
     assert sic(result.data["_service"]["sdl"]) == sic(type_defs)
+
+def test_federated_schema_version_detected():
+    type_defs = """
+        extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable", "@provides", "@external", "@tag", "@extends", "@override"]) 
+
+        type Product @key(fields: "upc") {
+            upc: String!
+            name: String
+            price: Int
+            weight: Int
+        }
+
+        type User @key(fields: "email") @extends {
+            email: ID! @external
+            name: String @override(from:"users")
+            totalProductsCreated: Int @external
+        } 
+    """
+
+    schema = make_federated_schema(type_defs)
+    result = graphql_sync(
+        schema,
+        """
+            query GetServiceDetails {
+                _service {
+                    sdl
+                }
+            }
+        """,
+    )
+
+    assert result.errors is None
+    assert sic(result.data["_service"]["sdl"]) == sic(type_defs)


### PR DESCRIPTION
As noted in #846, Ariadne currently doesn't support Federation 2, although it is currently possible to shim support by adding in the directive definitions manually. 

Instead of that, this PR allows Federation 2 schemas to be parsed without those additional definitions. Additionally, it supports detection of Federation 2 schemas via use of a regex (https://github.com/mirumee/ariadne/blob/cc2a4afbd53101b8bf98e382a4090da348252fab/ariadne/contrib/federation/schema.py#L89) to ensure only the correct definitions are pulled in. 

Once this PR is merged in, I'll work to add it to the `apollo-federation-subgraph-compatibility` repository to denote support, but an updated result shows: 

| Language | Library | Federation 1 Support | Federation 2 Support |
| --- | --- | --- | --- |
| Python | [Ariadne](https://ariadnegraphql.org/docs/apollo-federation) | <table><tr><th>_service</th><td>✅</td></tr><tr><th>@key (single)</th><td>✅</td></tr><tr><th>@key (multi)</th><td>✅</td></tr><tr><th>@key (composite)</th><td>✅</td></tr><tr><th>@requires</th><td>✅</td></tr><tr><th>@provides</th><td>✅</td></tr><tr><th>@ftv1</th><td>❌</td></tr></table> | <table><tr><th>@link</th><td>✅</td></tr><tr><th>@shareable</th><td>✅</td></tr><tr><th>@tag</th><td>✅</td></tr><tr><th>@override</th><td>✅</td></tr><tr><th>@inaccessible</th><td>✅</td></tr></table> |

Which matches with expectations. 

Since new directives don't require additional work by subgraphs, this is a simple passthrough for support. 

edit: updated support table, thanks for the callout @pigletto!