### PR TITLE
fix: add support for other common schema file extensions

### DIFF
--- a/ariadne/load_schema.py
+++ b/ariadne/load_schema.py
@@ -18,7 +18,7 @@ def walk_graphql_files(path: str) -> Generator[str, None, None]:
     extensions = (".graphql", ".graphqls", ".gql")
     for dirpath, _, files in os.walk(path):
         for name in files:
-            if extensions and name.lower().endswith(extensions):
+            if name.lower().endswith(extensions):
                 yield os.path.join(dirpath, name)
 
 

--- a/ariadne/load_schema.py
+++ b/ariadne/load_schema.py
@@ -15,10 +15,10 @@ def load_schema_from_path(path: str) -> str:
 
 
 def walk_graphql_files(path: str) -> Generator[str, None, None]:
-    extension = ".graphql"
+    extensions = (".graphql", ".graphqls", ".gql")
     for dirpath, _, files in os.walk(path):
         for name in files:
-            if extension and name.lower().endswith(extension):
+            if extensions and name.lower().endswith(extensions):
                 yield os.path.join(dirpath, name)
 
 


### PR DESCRIPTION
I find that there are a number of different schema file extensions in use out there in addition to `.graphql`. This PR adds support for some common ones supported by code editors, specifically `.graphqls` and `.gql`