### PR TITLE
Option to enable convert kwargs to snake case globally

### DIFF
--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -6,6 +6,7 @@ from graphql import (
     build_ast_schema,
     parse,
 )
+from graphql.type import GraphQLObjectType, GraphQLInputObjectType
 
 from .enums import (
     EnumType,
@@ -14,12 +15,14 @@ from .enums import (
 )
 from .schema_visitor import SchemaDirectiveVisitor
 from .types import SchemaBindable
+from .utils import convert_camel_case_to_snake
 
 
 def make_executable_schema(
     type_defs: Union[str, List[str]],
     *bindables: Union[SchemaBindable, List[SchemaBindable]],
     directives: Dict[str, Type[SchemaDirectiveVisitor]] = None,
+    convert_args_to_snake_case: bool = False,
 ) -> GraphQLSchema:
     if isinstance(type_defs, list):
         type_defs = join_type_defs(type_defs)
@@ -39,6 +42,9 @@ def make_executable_schema(
     assert_valid_schema(schema)
     validate_schema_enum_values(schema)
     repair_default_enum_values(schema, flat_bindables)
+
+    if convert_args_to_snake_case:
+        set_outnames_to_snake_case(schema)
 
     return schema
 
@@ -65,3 +71,14 @@ def repair_default_enum_values(schema, bindables) -> None:
     for bindable in bindables:
         if isinstance(bindable, EnumType):
             bindable.bind_to_default_values(schema)
+
+
+def set_outnames_to_snake_case(schema) -> None:
+    for graphql_type in schema.type_map.values():
+        if isinstance(graphql_type, GraphQLInputObjectType):
+            for field_name, field in graphql_type.fields.items():
+                field.out_name = convert_camel_case_to_snake(field_name)
+        if isinstance(graphql_type, GraphQLObjectType):
+            for field in graphql_type.fields.values():
+                for arg_name, arg in field.args.items():
+                    arg.out_name = convert_camel_case_to_snake(arg_name)

--- a/ariadne/load_schema.py
+++ b/ariadne/load_schema.py
@@ -18,7 +18,7 @@ def walk_graphql_files(path: str) -> Generator[str, None, None]:
     extensions = (".graphql", ".graphqls", ".gql")
     for dirpath, _, files in os.walk(path):
         for name in files:
-            if extensions and name.lower().endswith(extensions):
+            if name.lower().endswith(extensions):
                 yield os.path.join(dirpath, name)
 
 

--- a/ariadne/load_schema.py
+++ b/ariadne/load_schema.py
@@ -15,10 +15,10 @@ def load_schema_from_path(path: str) -> str:
 
 
 def walk_graphql_files(path: str) -> Generator[str, None, None]:
-    extension = ".graphql"
+    extensions = (".graphql", ".graphqls", ".gql")
     for dirpath, _, files in os.walk(path):
         for name in files:
-            if extension and name.lower().endswith(extension):
+            if extensions and name.lower().endswith(extensions):
                 yield os.path.join(dirpath, name)
 
 

--- a/ariadne/objects.py
+++ b/ariadne/objects.py
@@ -5,7 +5,6 @@ from graphql.type import GraphQLNamedType, GraphQLObjectType, GraphQLSchema
 from .resolvers import resolve_to
 from .types import Resolver, SchemaBindable
 
-
 class ObjectType(SchemaBindable):
     _resolvers: Dict[str, Resolver]
 
@@ -57,7 +56,7 @@ class ObjectType(SchemaBindable):
                 )
             if graphql_type.fields[field].resolve is None or replace_existing:
                 graphql_type.fields[field].resolve = resolver
-
+            
 
 class QueryType(ObjectType):
     """Convenience class for defining Query type"""


### PR DESCRIPTION
A global option for the `convert_kwargs_to_snake_case` decorator would be nice to have. This is especially useful if this is the desired behavior for all resolvers