### PR TITLE
Fix type signature for make_executable_schema

### DIFF
--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Type, Union, Optional
 
 from graphql import (
     GraphQLSchema,
@@ -19,7 +19,7 @@ from .types import SchemaBindable
 def make_executable_schema(
     type_defs: Union[str, List[str]],
     *bindables: Union[SchemaBindable, List[SchemaBindable]],
-    directives: Dict[str, Type[SchemaDirectiveVisitor]] = None,
+    directives: Optional[Dict[str, Type[SchemaDirectiveVisitor]]] = None,
 ) -> GraphQLSchema:
     if isinstance(type_defs, list):
         type_defs = join_type_defs(type_defs)


### PR DESCRIPTION
This PR changes `directives` to an `Optional`, since it can take a `None`.

It gets rid of this error message:

<img width="896" alt="Screenshot 2022-08-10 at 13 57 19" src="https://user-images.githubusercontent.com/514563/183908542-ec646893-80c6-4e0f-b8cb-438e57e0b0d6.png">
