### PR TITLE
fix #935 Remove duplicate validation error reported from the cost validator

### DIFF
--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -90,8 +90,7 @@ class CostValidator(ValidationRule):
                     field_args: Dict[str, Any] = get_argument_values(
                         field, child_node, self.variables
                     )
-                except Exception as e:
-                    report_error(self.context, e)
+                except Exception:
                     field_args = {}
                 if self.cost_map:
                     cost_map_args = (

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -458,3 +458,18 @@ def test_child_field_cost_defined_in_directive_is_multiplied_by_values_from_lite
             extensions={"cost": {"requestedQueryCost": 20, "maximumAvailable": 3}},
         )
     ]
+
+
+def test_field_input_errors_are_not_reported_from_cost_validator(
+    schema_with_costs,
+):
+    query = "{ child { name online } }"  # Invalid query; missing mandatory argument
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=3)
+    result = validate(schema_with_costs, ast, [rule])
+    assert result == [
+        GraphQLError(
+            "The query exceeds the maximum cost of 3. Actual cost is 4",
+            extensions={"cost": {"requestedQueryCost": 4, "maximumAvailable": 3}},
+        )
+    ]


### PR DESCRIPTION
I hope this explicit error can be removed safely as the cost validator has to report only its own errors.