### PR TITLE
Add support for passing execution context class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Added support for `@tag` directive used by Apollo Federation.
 - Updated `starlette` dependency in setup.py to `<1.0`.
 - Moved project configuration from `setup.py` to `pyproject.toml`.
+- Added `execution_context_class` option.
 
 
 ## 0.16.1 (2022-09-26)

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -57,6 +57,7 @@ async def graphql(
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
     extensions: Optional[ExtensionList] = None,
+    execution_context_class: Optional[Type[ExecutionContext]] = None,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions, context_value)
@@ -102,7 +103,7 @@ async def graphql(
                 context_value=context_value,
                 variable_values=variables,
                 operation_name=operation_name,
-                execution_context_class=ExecutionContext,
+                execution_context_class=execution_context_class,
                 middleware=extension_manager.as_middleware_manager(middleware),
                 **kwargs,
             )
@@ -140,6 +141,7 @@ def graphql_sync(
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
     extensions: Optional[ExtensionList] = None,
+    execution_context_class: Optional[Type[ExecutionContext]] = None,
     **kwargs,
 ) -> GraphQLResult:
     extension_manager = ExtensionManager(extensions, context_value)
@@ -189,7 +191,7 @@ def graphql_sync(
                 context_value=context_value,
                 variable_values=variables,
                 operation_name=operation_name,
-                execution_context_class=ExecutionContext,
+                execution_context_class=execution_context_class,
                 middleware=extension_manager.as_middleware_manager(middleware),
                 **kwargs,
             )

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,5 +1,5 @@
 import pytest
-from graphql import GraphQLError
+from graphql import ExecutionContext, GraphQLError
 from graphql.validation.rules import ValidationRule
 
 from ariadne import graphql, graphql_sync, subscribe
@@ -24,6 +24,20 @@ def test_graphql_sync_uses_validation_rules(schema):
     )
     assert not success
     assert result["errors"][0]["message"] == "Invalid"
+
+
+def test_graphql_sync_uses_execution_context_class(schema):
+    class TestExecutionContext(ExecutionContext):
+        def execute_field(self, *_):
+            return "test"
+
+    success, result = graphql_sync(
+        schema,
+        {"query": '{ hello(name: "world") }'},
+        execution_context_class=TestExecutionContext,
+    )
+    assert success
+    assert result["data"] == {"hello": "test"}
 
 
 def test_graphql_sync_prevents_introspection_query_when_option_is_disabled(schema):
@@ -51,6 +65,21 @@ async def test_graphql_uses_validation_rules(schema):
     )
     assert not success
     assert result["errors"][0]["message"] == "Invalid"
+
+
+@pytest.mark.asyncio
+async def test_graphql_uses_execution_context_class(schema):
+    class TestExecutionContext(ExecutionContext):
+        def execute_field(self, *_):
+            return "test"
+
+    success, result = await graphql(
+        schema,
+        {"query": '{ hello(name: "world") }'},
+        execution_context_class=TestExecutionContext,
+    )
+    assert success
+    assert result["data"] == {"hello": "test"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Allows customizing the `ExecutionContext` by passing an argument to `graphql` and `graphql_sync`. If the argument is not provided, the default execution context class is used (as before).

I intend to use this with [graphql-sync-dataloaders](https://github.com/jkimbo/graphql-sync-dataloaders). AFAIK, it's the most convenient way to use dataloaders in a non-async Django project.

See also #817. Please let me know of any problems!

---

PS.: Type checks on master are failing with the latest mypy version (0.990):
```
ariadne/resolvers.py:64: error: Function "Callable[..., Any]" could always be true in boolean context  [truthy-function]
```