### PR TITLE
Auto-run tests suite bi-weekly to catch eventual dependency breaks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request:
+  schedule:
+    - cron:  '0 7 * * 1,3'
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ on:
       - master
   pull_request:
   schedule:
-    - cron:  '0 7 * * 1,3'
+    - cron:  "0 7 * * 1,3"
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #969

#963 effectively unlocked most of Ariadne's dev dependencies, but we still need a way to catch situations when releases for those break the project. We could either lock and manually maintain those in `pyproject.toml`, but I think its preferable for library to leave dependency freeze decision for end users in their projects (until I get burned).

This PR extends tests workflow with scheduled run on mondays and wednesdays on 7 AM UTC time.