### PR TITLE
Make query parser configurable

### DIFF
--- a/ariadne/asgi/graphql.py
+++ b/ariadne/asgi/graphql.py
@@ -9,6 +9,7 @@ from ..format_error import format_error
 from ..types import (
     ContextValue,
     ErrorFormatter,
+    QueryParser,
     RootValue,
     ValidationRules,
 )
@@ -26,6 +27,7 @@ class GraphQL:
         *,
         context_value: Optional[ContextValue] = None,
         root_value: Optional[RootValue] = None,
+        query_parser: Optional[QueryParser] = None,
         validation_rules: Optional[ValidationRules] = None,
         debug: bool = False,
         introspection: bool = True,
@@ -52,6 +54,7 @@ class GraphQL:
             schema,
             context_value,
             root_value,
+            query_parser,
             validation_rules,
             debug,
             introspection,
@@ -63,6 +66,7 @@ class GraphQL:
             schema,
             context_value,
             root_value,
+            query_parser,
             validation_rules,
             debug,
             introspection,

--- a/ariadne/asgi/handlers/base.py
+++ b/ariadne/asgi/handlers/base.py
@@ -3,7 +3,7 @@ from inspect import isawaitable
 from logging import Logger, LoggerAdapter
 from typing import Any, Optional, Union
 
-from graphql import GraphQLSchema
+from graphql import DocumentNode, GraphQLSchema
 from starlette.types import Receive, Scope, Send
 
 from ...explorer import Explorer
@@ -16,6 +16,7 @@ from ...types import (
     OnConnect,
     OnDisconnect,
     OnOperation,
+    QueryParser,
     RootValue,
     ValidationRules,
 )
@@ -31,6 +32,7 @@ class GraphQLHandler(ABC):
         self.explorer: Optional[Explorer] = None
         self.logger: Union[None, str, Logger, LoggerAdapter] = None
         self.root_value: Optional[RootValue] = None
+        self.query_parser: Optional[QueryParser] = None
         self.validation_rules: Optional[ValidationRules] = None
 
     @abstractmethod
@@ -42,6 +44,7 @@ class GraphQLHandler(ABC):
         schema: GraphQLSchema,
         context_value: Optional[ContextValue] = None,
         root_value: Optional[RootValue] = None,
+        query_parser: Optional[QueryParser] = None,
         validation_rules: Optional[ValidationRules] = None,
         debug: bool = False,
         introspection: bool = True,
@@ -55,6 +58,7 @@ class GraphQLHandler(ABC):
         self.introspection = introspection
         self.explorer = explorer
         self.logger = logger
+        self.query_parser = query_parser
         self.root_value = root_value
         self.schema = schema
         self.validation_rules = validation_rules
@@ -74,7 +78,14 @@ class GraphQLHandler(ABC):
 
 class GraphQLHttpHandlerBase(GraphQLHandler):
     @abstractmethod
-    async def execute_graphql_query(self, request: Any, data: Any) -> GraphQLResult:
+    async def execute_graphql_query(
+        self,
+        request: Any,
+        data: Any,
+        *,
+        context_value: Optional[Any] = None,
+        query_document: Optional[DocumentNode] = None,
+    ) -> GraphQLResult:
         """Execute query"""
 
 

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -2,6 +2,7 @@ import json
 from inspect import isawaitable
 from typing import Any, Optional, cast
 
+from graphql import DocumentNode
 from graphql.execution import MiddlewareManager
 from starlette.datastructures import UploadFile
 from starlette.requests import Request
@@ -80,8 +81,17 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
             return MiddlewareManager(*middleware)
         return None
 
-    async def execute_graphql_query(self, request: Any, data: Any) -> GraphQLResult:
-        context_value = await self.get_context_for_request(request)
+    async def execute_graphql_query(
+        self,
+        request: Any,
+        data: Any,
+        *,
+        context_value: Any = None,
+        query_document: Optional[DocumentNode] = None,
+    ) -> GraphQLResult:
+        if context_value is None:
+            context_value = await self.get_context_for_request(request)
+
         extensions = await self.get_extensions_for_request(request, context_value)
         middleware = await self.get_middleware_for_request(request, context_value)
 
@@ -93,6 +103,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
             data,
             context_value=context_value,
             root_value=self.root_value,
+            query_parser=self.query_parser,
             validation_rules=self.validation_rules,
             debug=self.debug,
             introspection=self.introspection,

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -41,6 +41,8 @@ ErrorFormatter = Callable[[GraphQLError, bool], dict]
 ContextValue = Union[Any, Callable[[Any], Any]]
 RootValue = Union[Any, Callable[[Optional[Any], DocumentNode], Any]]
 
+QueryParser = Callable[[ContextValue, str], DocumentNode]
+
 ValidationRules = Union[
     Collection[Type[ASTValidationRule]],
     Callable[
@@ -50,7 +52,6 @@ ValidationRules = Union[
 ]
 
 ExtensionList = Optional[List[Union[Type["Extension"], Callable[[], "Extension"]]]]
-
 
 Extensions = Union[
     Callable[[Any, Optional[ContextValue]], ExtensionList], ExtensionList

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -26,6 +26,7 @@ from .types import (
     ErrorFormatter,
     ExtensionList,
     GraphQLResult,
+    QueryParser,
     RootValue,
     ValidationRules,
 )
@@ -46,6 +47,7 @@ class GraphQL:
         *,
         context_value: Optional[ContextValue] = None,
         root_value: Optional[RootValue] = None,
+        query_parser: Optional[QueryParser] = None,
         validation_rules: Optional[ValidationRules] = None,
         debug: bool = False,
         introspection: bool = True,
@@ -57,6 +59,7 @@ class GraphQL:
     ) -> None:
         self.context_value = context_value
         self.root_value = root_value
+        self.query_parser = query_parser
         self.validation_rules = validation_rules
         self.debug = debug
         self.introspection = introspection
@@ -196,6 +199,7 @@ class GraphQL:
             data,
             context_value=context_value,
             root_value=self.root_value,
+            query_parser=self.query_parser,
             validation_rules=self.validation_rules,
             debug=self.debug,
             introspection=self.introspection,


### PR DESCRIPTION
Adds `query_parser` option to the WSGI and ASGI `GraphQL` applications. This feature opens gate to implementing custom query parsers that (for example) cache parsing results or only allow queries from given subset defined on the server.

Fixes #976