### PR TITLE
Tweak middleware options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Moved project configuration from `setup.py` to `pyproject.toml`.
 - Added `execution_context_class` option to ASGI and WSGI `applications`.
 - Added `query_parser` option to ASGI and WSGI `GraphQL` applications that enables query parsing customization.
+- Changed `middleware` option to work with callable or list of middlewares instead of `MiddlewareManager` instance.
+- Added `middleware_manager_class` option to ASGI and WSGI `applications`.
 - Added Python 3.11 support.
 
 

--- a/ariadne/asgi/handlers/base.py
+++ b/ariadne/asgi/handlers/base.py
@@ -3,7 +3,7 @@ from inspect import isawaitable
 from logging import Logger, LoggerAdapter
 from typing import Any, Optional, Type, Union
 
-from graphql import DocumentNode, ExecutionContext, GraphQLSchema
+from graphql import DocumentNode, ExecutionContext, GraphQLSchema, MiddlewareManager
 from starlette.types import Receive, Scope, Send
 
 from ...explorer import Explorer
@@ -35,6 +35,7 @@ class GraphQLHandler(ABC):
         self.query_parser: Optional[QueryParser] = None
         self.validation_rules: Optional[ValidationRules] = None
         self.execution_context_class: Optional[Type[ExecutionContext]] = None
+        self.middleware_manager_class: Optional[Type[MiddlewareManager]] = None
 
     @abstractmethod
     async def handle(self, scope: Scope, receive: Receive, send: Send):

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -21,6 +21,7 @@ from ...types import (
     ExtensionList,
     Extensions,
     GraphQLResult,
+    MiddlewareList,
     Middlewares,
 )
 from .base import GraphQLHttpHandlerBase
@@ -71,7 +72,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
 
     async def get_middleware_for_request(
         self, request: Any, context: Optional[ContextValue]
-    ) -> Optional[Middlewares]:
+    ) -> MiddlewareList:
         middleware = self.middleware
         if callable(middleware):
             middleware = middleware(request, context)

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -1,9 +1,8 @@
 import json
 from inspect import isawaitable
-from typing import Any, Optional, cast
+from typing import Any, Optional, Type, cast
 
-from graphql import DocumentNode
-from graphql.execution import MiddlewareManager
+from graphql import DocumentNode, MiddlewareManager
 from starlette.datastructures import UploadFile
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, PlainTextResponse, Response
@@ -32,11 +31,13 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
         self,
         extensions: Optional[Extensions] = None,
         middleware: Optional[Middlewares] = None,
+        middleware_manager_class: Optional[Type[MiddlewareManager]] = None,
     ) -> None:
         super().__init__()
 
         self.extensions = extensions
         self.middleware = middleware
+        self.middleware_manager_class = middleware_manager_class or MiddlewareManager
 
     async def handle(self, scope: Scope, receive: Receive, send: Send):
         request = Request(scope=scope, receive=receive)
@@ -70,15 +71,14 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
 
     async def get_middleware_for_request(
         self, request: Any, context: Optional[ContextValue]
-    ) -> Optional[MiddlewareManager]:
+    ) -> Optional[Middlewares]:
         middleware = self.middleware
         if callable(middleware):
             middleware = middleware(request, context)
             if isawaitable(middleware):
                 middleware = await middleware  # type: ignore
         if middleware:
-            middleware = cast(list, middleware)
-            return MiddlewareManager(*middleware)
+            return cast(list, middleware)
         return None
 
     async def execute_graphql_query(
@@ -112,6 +112,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
             error_formatter=self.error_formatter,
             extensions=extensions,
             middleware=middleware,
+            middleware_manager_class=self.middleware_manager_class,
             execution_context_class=self.execution_context_class,
         )
 

--- a/ariadne/extensions.py
+++ b/ariadne/extensions.py
@@ -1,8 +1,8 @@
 from contextlib import contextmanager
-from typing import List, Optional
+from typing import List, Optional, Sequence, Type
 
 from graphql import GraphQLError
-from graphql.execution import MiddlewareManager
+from graphql.execution import Middleware, MiddlewareManager
 
 from .types import ContextValue, ExtensionList
 
@@ -24,11 +24,18 @@ class ExtensionManager:
             self.extensions_reversed = self.extensions = tuple()
 
     def as_middleware_manager(
-        self, manager: Optional[MiddlewareManager]
-    ) -> MiddlewareManager:
-        if manager and manager.middlewares:
-            return MiddlewareManager(*manager.middlewares, *self.extensions)
-        return MiddlewareManager(*self.extensions)
+        self,
+        middleware: Optional[Sequence[Middleware]] = None,
+        manager_class: Optional[Type[MiddlewareManager]] = None,
+    ) -> Optional[MiddlewareManager]:
+        if not middleware and not self.extensions:
+            return None
+
+        middleware = middleware or []
+        if manager_class:
+            return manager_class(*middleware, *self.extensions)
+
+        return MiddlewareManager(*middleware, *self.extensions)
 
     @contextmanager
     def request(self):

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -20,13 +20,14 @@ from graphql import (
     ExecutionResult,
     GraphQLError,
     GraphQLSchema,
+    Middleware,
+    MiddlewareManager,
     TypeInfo,
     execute,
     execute_sync,
     parse,
     subscribe as _subscribe,
 )
-from graphql.execution import MiddlewareManager
 from graphql.validation import specified_rules, validate
 from graphql.validation.rules import ASTValidationRule
 
@@ -58,7 +59,8 @@ async def graphql(
     logger: Union[None, str, Logger, LoggerAdapter] = None,
     validation_rules: Optional[ValidationRules] = None,
     error_formatter: ErrorFormatter = format_error,
-    middleware: Optional[MiddlewareManager] = None,
+    middleware: Optional[Sequence[Middleware]] = None,
+    middleware_manager_class: Optional[Type[MiddlewareManager]] = None,
     extensions: Optional[ExtensionList] = None,
     execution_context_class: Optional[Type[ExecutionContext]] = None,
     **kwargs,
@@ -109,7 +111,9 @@ async def graphql(
                 variable_values=variables,
                 operation_name=operation_name,
                 execution_context_class=execution_context_class,
-                middleware=extension_manager.as_middleware_manager(middleware),
+                middleware=extension_manager.as_middleware_manager(
+                    middleware, middleware_manager_class
+                ),
                 **kwargs,
             )
 
@@ -147,6 +151,7 @@ def graphql_sync(
     validation_rules: Optional[ValidationRules] = None,
     error_formatter: ErrorFormatter = format_error,
     middleware: Optional[MiddlewareManager] = None,
+    middleware_manager_class: Optional[Type[MiddlewareManager]] = None,
     extensions: Optional[ExtensionList] = None,
     execution_context_class: Optional[Type[ExecutionContext]] = None,
     **kwargs,
@@ -201,7 +206,9 @@ def graphql_sync(
                 variable_values=variables,
                 operation_name=operation_name,
                 execution_context_class=execution_context_class,
-                middleware=extension_manager.as_middleware_manager(middleware),
+                middleware=extension_manager.as_middleware_manager(
+                    middleware, middleware_manager_class
+                ),
                 **kwargs,
             )
 

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -150,7 +150,7 @@ def graphql_sync(
     logger: Union[None, str, Logger, LoggerAdapter] = None,
     validation_rules: Optional[ValidationRules] = None,
     error_formatter: ErrorFormatter = format_error,
-    middleware: Optional[MiddlewareManager] = None,
+    middleware: Optional[Sequence[Middleware]] = None,
     middleware_manager_class: Optional[Type[MiddlewareManager]] = None,
     extensions: Optional[ExtensionList] = None,
     execution_context_class: Optional[Type[ExecutionContext]] = None,

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -53,10 +53,10 @@ ValidationRules = Union[
 ]
 
 ExtensionList = Optional[List[Union[Type["Extension"], Callable[[], "Extension"]]]]
-
 Extensions = Union[
     Callable[[Any, Optional[ContextValue]], ExtensionList], ExtensionList
 ]
+
 MiddlewareList = Optional[List[Middleware]]
 Middlewares = Union[
     Callable[[Any, Optional[ContextValue]], MiddlewareList], MiddlewareList


### PR DESCRIPTION
Changes `middleware` option on ASGI and WSGI apps to be either:

- `None`
- List of middlewares
- Callable returning either `None` or list of middlewares

Also added `middleware_management_class` option for middleware manager customization.

This is departure from current implementation that required `MiddlewareManager` in place of middlewares list, but that's better for two reasons:

- Our docs already tell people to pass Middlewares list
- Extensions discarded whatever MiddlewareManager was used and replaced it with standard one.

Fixes #256 