### PR TITLE
Add data as second argument to context_value callable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Changed `logger` option to also support `Logger` and `LoggerAdapter` instance in addition to `str` with logger name.
 - Added support for `@tag` directive used by Apollo Federation.
 - Moved project configuration from `setup.py` to `pyproject.toml`.
+- Changed `context_value` option in ASGI and WSGI applications for callables to take query data as second argument.
 - Changed `root_value` option in ASGI and WSGI applications for callables to take operation and and variables in addition to context and parsed query.
 - Added `execution_context_class` option to ASGI and WSGI applications.
 - Added `query_parser` option to ASGI and WSGI `GraphQL` applications that enables query parsing customization.

--- a/ariadne/asgi/handlers/base.py
+++ b/ariadne/asgi/handlers/base.py
@@ -70,9 +70,10 @@ class GraphQLHandler(ABC):
     async def get_context_for_request(
         self,
         request: Any,
+        data: dict,
     ) -> Any:
         if callable(self.context_value):
-            context = self.context_value(request)
+            context = self.context_value(request, data)
             if isawaitable(context):
                 context = await context
             return context

--- a/ariadne/asgi/handlers/base.py
+++ b/ariadne/asgi/handlers/base.py
@@ -73,7 +73,7 @@ class GraphQLHandler(ABC):
         data: dict,
     ) -> Any:
         if callable(self.context_value):
-            context = self.context_value(request, data)
+            context = self.context_value(request, data)  # type: ignore
             if isawaitable(context):
                 context = await context
             return context

--- a/ariadne/asgi/handlers/graphql_transport_ws.py
+++ b/ariadne/asgi/handlers/graphql_transport_ws.py
@@ -181,7 +181,7 @@ class GraphQLTransportWSHandler(GraphQLWebsocketHandler):
 
         validate_data(data)
 
-        context_value = await self.get_context_for_request(websocket)
+        context_value = await self.get_context_for_request(websocket, data)
 
         try:
             query_document = parse_query(context_value, self.query_parser, data)

--- a/ariadne/asgi/handlers/graphql_ws.py
+++ b/ariadne/asgi/handlers/graphql_ws.py
@@ -110,7 +110,7 @@ class GraphQLWSHandler(GraphQLWebsocketHandler):
         operations: Dict[str, Operation],
     ) -> None:
         validate_data(data)
-        context_value = await self.get_context_for_request(websocket)
+        context_value = await self.get_context_for_request(websocket, data)
 
         try:
             query_document = parse_query(context_value, self.query_parser, data)

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -91,7 +91,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
         query_document: Optional[DocumentNode] = None,
     ) -> GraphQLResult:
         if context_value is None:
-            context_value = await self.get_context_for_request(request)
+            context_value = await self.get_context_for_request(request, data)
 
         extensions = await self.get_extensions_for_request(request, context_value)
         middleware = await self.get_middleware_for_request(request, context_value)

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -39,7 +39,11 @@ SubscriptionResult = Tuple[
 Subscriber = Callable[..., AsyncGenerator]
 ErrorFormatter = Callable[[GraphQLError, bool], dict]
 
-ContextValue = Union[Any, Callable[[Any], Any]]
+ContextValue = Union[
+    Any,
+    Callable[[Any], Any],  # TODO: remove in 0.19
+    Callable[[Any, dict], Any],
+]
 RootValue = Union[
     Any,
     Callable[[Optional[Any], DocumentNode], Any],  # TODO: remove in 0.19

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -206,7 +206,7 @@ class GraphQL:
         return combine_multipart_data(operations, files_map, form.files)
 
     def execute_query(self, environ: dict, data: dict) -> GraphQLResult:
-        context_value = self.get_context_for_request(environ)
+        context_value = self.get_context_for_request(environ, data)
         extensions = self.get_extensions_for_request(environ, context_value)
         middleware = self.get_middleware_for_request(environ, context_value)
 
@@ -227,9 +227,9 @@ class GraphQL:
             execution_context_class=self.execution_context_class,
         )
 
-    def get_context_for_request(self, environ: dict) -> Optional[ContextValue]:
+    def get_context_for_request(self, environ: dict, data: dict) -> Optional[ContextValue]:
         if callable(self.context_value):
-            return self.context_value(environ)
+            return self.context_value(environ, data)
         return self.context_value or {"request": environ}
 
     def get_extensions_for_request(

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -227,9 +227,11 @@ class GraphQL:
             execution_context_class=self.execution_context_class,
         )
 
-    def get_context_for_request(self, environ: dict, data: dict) -> Optional[ContextValue]:
+    def get_context_for_request(
+        self, environ: dict, data: dict
+    ) -> Optional[ContextValue]:
         if callable(self.context_value):
-            return self.context_value(environ, data)
+            return self.context_value(environ, data)  # type: ignore
         return self.context_value or {"request": environ}
 
     def get_extensions_for_request(

--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -30,7 +30,7 @@ def test_custom_context_value_function_is_set_and_called_by_app(schema):
     app = GraphQL(schema, context_value=get_context_value)
     client = TestClient(app)
     client.post("/", json={"query": "{ status }"})
-    get_context_value.assert_called_once()
+    get_context_value.assert_called_once_with(ANY, {"query": "{ status }"})
 
 
 def test_custom_context_value_function_result_is_passed_to_resolvers(schema):

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -47,7 +47,7 @@ def test_custom_context_value_function_is_called_with_request_value(schema):
     app = GraphQL(schema, context_value=get_context_value)
     request = {"CONTENT_TYPE": DATA_TYPE_JSON}
     app.execute_query(request, {"query": "{ status }"})
-    get_context_value.assert_called_once_with(request)
+    get_context_value.assert_called_once_with(request, {"query": "{ status }"})
 
 
 def test_custom_context_value_function_result_is_passed_to_resolvers(schema):


### PR DESCRIPTION
Currently `context_value` function is called with single argument: instance of HTTP request specific to the framework.

It may be useful for context creation to access cleaned query payload, eg. to pre-warm custom query parser which doesn't support async for performance reasons.

Fixes #843