### PR TITLE
Make load-schema functions accept path-like objects

### DIFF
--- a/ariadne/load_schema.py
+++ b/ariadne/load_schema.py
@@ -7,16 +7,14 @@ from graphql.error import GraphQLSyntaxError
 from .exceptions import GraphQLFileSyntaxError
 
 
-def load_schema_from_path(path: Union[str, bytes, os.PathLike]) -> str:
+def load_schema_from_path(path: Union[str, os.PathLike]) -> str:
     if os.path.isdir(path):
         schema_list = [read_graphql_file(f) for f in sorted(walk_graphql_files(path))]
         return "\n".join(schema_list)
     return read_graphql_file(os.path.abspath(path))
 
 
-def walk_graphql_files(
-    path: Union[str, bytes, os.PathLike]
-) -> Generator[str, None, None]:
+def walk_graphql_files(path: Union[str, os.PathLike]) -> Generator[str, None, None]:
     extensions = (".graphql", ".graphqls", ".gql")
     for dirpath, _, files in os.walk(str(path)):
         for name in files:
@@ -24,7 +22,7 @@ def walk_graphql_files(
                 yield os.path.join(dirpath, name)
 
 
-def read_graphql_file(path: Union[str, bytes, os.PathLike]) -> str:
+def read_graphql_file(path: Union[str, os.PathLike]) -> str:
     with open(path, "r", encoding="utf-8") as graphql_file:
         schema = graphql_file.read()
     try:

--- a/ariadne/load_schema.py
+++ b/ariadne/load_schema.py
@@ -1,5 +1,5 @@
 import os
-from typing import Generator
+from typing import Generator, Union
 
 from graphql import parse
 from graphql.error import GraphQLSyntaxError
@@ -7,22 +7,24 @@ from graphql.error import GraphQLSyntaxError
 from .exceptions import GraphQLFileSyntaxError
 
 
-def load_schema_from_path(path: str) -> str:
+def load_schema_from_path(path: Union[str, bytes, os.PathLike]) -> str:
     if os.path.isdir(path):
         schema_list = [read_graphql_file(f) for f in sorted(walk_graphql_files(path))]
         return "\n".join(schema_list)
     return read_graphql_file(os.path.abspath(path))
 
 
-def walk_graphql_files(path: str) -> Generator[str, None, None]:
+def walk_graphql_files(
+    path: Union[str, bytes, os.PathLike]
+) -> Generator[str, None, None]:
     extensions = (".graphql", ".graphqls", ".gql")
-    for dirpath, _, files in os.walk(path):
+    for dirpath, _, files in os.walk(str(path)):
         for name in files:
             if name.lower().endswith(extensions):
                 yield os.path.join(dirpath, name)
 
 
-def read_graphql_file(path: str) -> str:
+def read_graphql_file(path: Union[str, bytes, os.PathLike]) -> str:
     with open(path, "r", encoding="utf-8") as graphql_file:
         schema = graphql_file.read()
     try:

--- a/tests/test_schema_file_load.py
+++ b/tests/test_schema_file_load.py
@@ -25,6 +25,7 @@ def single_file_schema(tmpdir_factory):
 
 def test_load_schema_from_single_file(single_file_schema):
     assert load_schema_from_path(str(single_file_schema)) == FIRST_SCHEMA
+    assert load_schema_from_path(pathlib.Path(single_file_schema)) == FIRST_SCHEMA
 
 
 INCORRECT_SCHEMA = """
@@ -70,6 +71,9 @@ def schema_directory(tmpdir_factory):
 
 def test_loading_schema_from_directory(schema_directory):
     assert load_schema_from_path(str(schema_directory)) == "\n".join(
+        [FIRST_SCHEMA, SECOND_SCHEMA]
+    )
+    assert load_schema_from_path(pathlib.Path(schema_directory)) == "\n".join(
         [FIRST_SCHEMA, SECOND_SCHEMA]
     )
 


### PR DESCRIPTION
Otherwise, a call like `load_schema_from_path(dir)`, with `dir = pathlib.Path(...)`, is being reported by mypy as an error.