### PR TITLE
Add option for names conversion to `make_executable_schema`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added `explorer` option to ASGI and WSGI `GraphQL` applications that enables API explorer customization.
 - Added `ExplorerHttp405` API explorer that returns `405 Method Not Allowed` for GET HTTP requests.
 - Added implementations for GraphiQL2, GraphQL-Playground and Apollo Sandbox explorers.
+- Added `convert_names_case` option to `make_executable_schema` to convert all names in schema to Python case using default or custom strategy.
 - Changed `logger` option to also support `Logger` and `LoggerAdapter` instance in addition to `str` with logger name.
 - Added support for `@tag` directive used by Apollo Federation.
 - Moved project configuration from `setup.py` to `pyproject.toml`.

--- a/ariadne/__init__.py
+++ b/ariadne/__init__.py
@@ -27,6 +27,7 @@ from .resolvers import (
     snake_case_fallback_resolvers,
 )
 from .scalars import ScalarType
+from .schema_names import SchemaNameConverter, convert_schema_names
 from .schema_visitor import SchemaDirectiveVisitor
 from .subscriptions import SubscriptionType
 from .types import SchemaBindable
@@ -49,12 +50,14 @@ __all__ = [
     "ScalarType",
     "SchemaBindable",
     "SchemaDirectiveVisitor",
+    "SchemaNameConverter",
     "SnakeCaseFallbackResolversSetter",
     "SubscriptionType",
     "UnionType",
     "combine_multipart_data",
     "convert_camel_case_to_snake",
     "convert_kwargs_to_snake_case",
+    "convert_schema_names",
     "fallback_resolvers",
     "format_error",
     "get_error_extension",

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -1,6 +1,11 @@
-from typing import Dict, List, Optional, Type, Union
+from typing import Callable, Dict, List, Optional, Type, Union
 
 from graphql import (
+    GraphQLArgument,
+    GraphQLField,
+    GraphQLInputField,
+    GraphQLInputObjectType,
+    GraphQLObjectType,
     GraphQLSchema,
     assert_valid_schema,
     build_ast_schema,
@@ -12,14 +17,23 @@ from .enums import (
     set_default_enum_values_on_schema,
     validate_schema_enum_values,
 )
+from .resolvers import resolve_to
 from .schema_visitor import SchemaDirectiveVisitor
 from .types import SchemaBindable
+from .utils import convert_camel_case_to_snake
+
+
+ConvertNameCaseCallable = Callable[
+    [str, Type[Union[GraphQLArgument, GraphQLField, GraphQLInputField]]], str
+]
+ConvertNameCase = Union[bool, ConvertNameCaseCallable]
 
 
 def make_executable_schema(
     type_defs: Union[str, List[str]],
     *bindables: Union[SchemaBindable, List[SchemaBindable]],
     directives: Optional[Dict[str, Type[SchemaDirectiveVisitor]]] = None,
+    convert_names_case: ConvertNameCase = False,
 ) -> GraphQLSchema:
     if isinstance(type_defs, list):
         type_defs = join_type_defs(type_defs)
@@ -39,6 +53,12 @@ def make_executable_schema(
     assert_valid_schema(schema)
     validate_schema_enum_values(schema)
     repair_default_enum_values(schema, flat_bindables)
+
+    if convert_names_case:
+        convert_names_in_schema(
+            schema,
+            convert_names_case if callable(convert_names_case) else None,
+        )
 
     return schema
 
@@ -65,3 +85,69 @@ def repair_default_enum_values(schema, bindables) -> None:
     for bindable in bindables:
         if isinstance(bindable, EnumType):
             bindable.bind_to_default_values(schema)
+
+
+GRAPHQL_SPEC_TYPES = (
+    "__Directive",
+    "__EnumValue",
+    "__Field",
+    "__InputValue",
+    "__Schema",
+    "__Type",
+)
+
+
+def convert_names_in_schema(
+    schema: GraphQLSchema,
+    strategy: Optional[ConvertNameCaseCallable],
+) -> None:
+    strategy = strategy or default_convert_name_case_strategy
+
+    for type_name, graphql_type in schema.type_map.items():
+        if (
+            isinstance(graphql_type, GraphQLObjectType)
+            and type_name not in GRAPHQL_SPEC_TYPES
+        ):
+            convert_names_in_schema_object(graphql_type, strategy)
+        if isinstance(graphql_type, GraphQLInputObjectType):
+            convert_names_in_schema_input(graphql_type, strategy)
+
+
+def convert_names_in_schema_object(
+    graphql_type: GraphQLObjectType,
+    strategy: ConvertNameCaseCallable,
+) -> None:
+    for field_name, field in graphql_type.fields.items():
+        if field.args:
+            convert_names_in_schema_args(field, strategy)
+
+        if field.resolve or field_name.lower() == field_name:
+            continue
+
+        field.resolve = resolve_to(strategy(field_name, GraphQLField))
+
+
+def convert_names_in_schema_args(
+    graphql_type: GraphQLField,
+    strategy: ConvertNameCaseCallable,
+) -> None:
+    for arg_name, arg in graphql_type.args.items():
+        if arg.out_name or arg_name.lower() == arg_name:
+            continue
+
+        arg.out_name = strategy(arg_name, GraphQLInputField)
+
+
+def convert_names_in_schema_input(
+    graphql_type: GraphQLInputObjectType,
+    strategy: ConvertNameCaseCallable,
+) -> None:
+    for field_name, field in graphql_type.fields.items():
+        if field.out_name or field_name.lower() == field_name:
+            continue
+
+        field.out_name = strategy(field_name, GraphQLInputField)
+
+
+def default_convert_name_case_strategy(graphql_name: str, _) -> str:
+    return convert_camel_case_to_snake(graphql_name)

--- a/ariadne/executable_schema.py
+++ b/ariadne/executable_schema.py
@@ -1,11 +1,6 @@
-from typing import Callable, Dict, List, Optional, Type, Union
+from typing import Dict, List, Optional, Type, Union
 
 from graphql import (
-    GraphQLArgument,
-    GraphQLField,
-    GraphQLInputField,
-    GraphQLInputObjectType,
-    GraphQLObjectType,
     GraphQLSchema,
     assert_valid_schema,
     build_ast_schema,
@@ -17,23 +12,16 @@ from .enums import (
     set_default_enum_values_on_schema,
     validate_schema_enum_values,
 )
-from .resolvers import resolve_to
+from .schema_names import SchemaNameConverter, convert_schema_names
 from .schema_visitor import SchemaDirectiveVisitor
 from .types import SchemaBindable
-from .utils import convert_camel_case_to_snake
-
-
-ConvertNameCaseCallable = Callable[
-    [str, Type[Union[GraphQLArgument, GraphQLField, GraphQLInputField]]], str
-]
-ConvertNameCase = Union[bool, ConvertNameCaseCallable]
 
 
 def make_executable_schema(
     type_defs: Union[str, List[str]],
     *bindables: Union[SchemaBindable, List[SchemaBindable]],
     directives: Optional[Dict[str, Type[SchemaDirectiveVisitor]]] = None,
-    convert_names_case: ConvertNameCase = False,
+    convert_names_case: Union[bool, SchemaNameConverter] = False,
 ) -> GraphQLSchema:
     if isinstance(type_defs, list):
         type_defs = join_type_defs(type_defs)
@@ -55,7 +43,7 @@ def make_executable_schema(
     repair_default_enum_values(schema, flat_bindables)
 
     if convert_names_case:
-        convert_names_in_schema(
+        convert_schema_names(
             schema,
             convert_names_case if callable(convert_names_case) else None,
         )
@@ -85,69 +73,3 @@ def repair_default_enum_values(schema, bindables) -> None:
     for bindable in bindables:
         if isinstance(bindable, EnumType):
             bindable.bind_to_default_values(schema)
-
-
-GRAPHQL_SPEC_TYPES = (
-    "__Directive",
-    "__EnumValue",
-    "__Field",
-    "__InputValue",
-    "__Schema",
-    "__Type",
-)
-
-
-def convert_names_in_schema(
-    schema: GraphQLSchema,
-    strategy: Optional[ConvertNameCaseCallable],
-) -> None:
-    strategy = strategy or default_convert_name_case_strategy
-
-    for type_name, graphql_type in schema.type_map.items():
-        if (
-            isinstance(graphql_type, GraphQLObjectType)
-            and type_name not in GRAPHQL_SPEC_TYPES
-        ):
-            convert_names_in_schema_object(graphql_type, strategy)
-        if isinstance(graphql_type, GraphQLInputObjectType):
-            convert_names_in_schema_input(graphql_type, strategy)
-
-
-def convert_names_in_schema_object(
-    graphql_type: GraphQLObjectType,
-    strategy: ConvertNameCaseCallable,
-) -> None:
-    for field_name, field in graphql_type.fields.items():
-        if field.args:
-            convert_names_in_schema_args(field, strategy)
-
-        if field.resolve or field_name.lower() == field_name:
-            continue
-
-        field.resolve = resolve_to(strategy(field_name, GraphQLField))
-
-
-def convert_names_in_schema_args(
-    graphql_type: GraphQLField,
-    strategy: ConvertNameCaseCallable,
-) -> None:
-    for arg_name, arg in graphql_type.args.items():
-        if arg.out_name or arg_name.lower() == arg_name:
-            continue
-
-        arg.out_name = strategy(arg_name, GraphQLInputField)
-
-
-def convert_names_in_schema_input(
-    graphql_type: GraphQLInputObjectType,
-    strategy: ConvertNameCaseCallable,
-) -> None:
-    for field_name, field in graphql_type.fields.items():
-        if field.out_name or field_name.lower() == field_name:
-            continue
-
-        field.out_name = strategy(field_name, GraphQLInputField)
-
-
-def default_convert_name_case_strategy(graphql_name: str, _) -> str:
-    return convert_camel_case_to_snake(graphql_name)

--- a/ariadne/schema_names.py
+++ b/ariadne/schema_names.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Type, Union
+from typing import Callable, Optional, Tuple, Union
 
 from graphql import (
     GraphQLArgument,
@@ -13,7 +13,15 @@ from .resolvers import resolve_to
 from .utils import convert_camel_case_to_snake
 
 SchemaNameConverter = Callable[
-    [str, Type[Union[GraphQLArgument, GraphQLField, GraphQLInputField]]], str
+    [
+        str,
+        Union[
+            Tuple[GraphQLObjectType, GraphQLField],
+            Tuple[GraphQLObjectType, GraphQLField, GraphQLArgument],
+            Tuple[GraphQLInputObjectType, GraphQLInputField],
+        ],
+    ],
+    str,
 ]
 
 GRAPHQL_SPEC_TYPES = (
@@ -43,40 +51,41 @@ def convert_schema_names(
 
 
 def convert_names_in_schema_object(
-    graphql_type: GraphQLObjectType,
+    graphql_object: GraphQLObjectType,
     name_converter: SchemaNameConverter,
 ) -> None:
-    for field_name, field in graphql_type.fields.items():
+    for field_name, field in graphql_object.fields.items():
         if field.args:
-            convert_names_in_schema_args(field, name_converter)
+            convert_names_in_schema_args(graphql_object, field, name_converter)
 
         if field.resolve or field_name.lower() == field_name:
             continue
 
-        field.resolve = resolve_to(name_converter(field_name, GraphQLField))
+        field.resolve = resolve_to(name_converter(field_name, (graphql_object, field)))
 
 
 def convert_names_in_schema_args(
-    graphql_type: GraphQLField,
+    graphql_object: GraphQLObjectType,
+    graphql_field: GraphQLField,
     name_converter: SchemaNameConverter,
 ) -> None:
-    for arg_name, arg in graphql_type.args.items():
+    for arg_name, arg in graphql_field.args.items():
         if arg.out_name or arg_name.lower() == arg_name:
             continue
 
-        arg.out_name = name_converter(arg_name, GraphQLInputField)
+        arg.out_name = name_converter(arg_name, (graphql_object, graphql_field, arg))
 
 
 def convert_names_in_schema_input(
-    graphql_type: GraphQLInputObjectType,
+    graphql_input: GraphQLInputObjectType,
     name_converter: SchemaNameConverter,
 ) -> None:
-    for field_name, field in graphql_type.fields.items():
+    for field_name, field in graphql_input.fields.items():
         if field.out_name or field_name.lower() == field_name:
             continue
 
-        field.out_name = name_converter(field_name, GraphQLInputField)
+        field.out_name = name_converter(field_name, (graphql_input, field))
 
 
-def default_schema_name_converter(graphql_name: str, _graphql_type) -> str:
+def default_schema_name_converter(graphql_name: str, _path) -> str:
     return convert_camel_case_to_snake(graphql_name)

--- a/ariadne/schema_names.py
+++ b/ariadne/schema_names.py
@@ -1,0 +1,82 @@
+from typing import Callable, Optional, Type, Union
+
+from graphql import (
+    GraphQLArgument,
+    GraphQLField,
+    GraphQLInputField,
+    GraphQLInputObjectType,
+    GraphQLObjectType,
+    GraphQLSchema,
+)
+
+from .resolvers import resolve_to
+from .utils import convert_camel_case_to_snake
+
+SchemaNameConverter = Callable[
+    [str, Type[Union[GraphQLArgument, GraphQLField, GraphQLInputField]]], str
+]
+
+GRAPHQL_SPEC_TYPES = (
+    "__Directive",
+    "__EnumValue",
+    "__Field",
+    "__InputValue",
+    "__Schema",
+    "__Type",
+)
+
+
+def convert_schema_names(
+    schema: GraphQLSchema,
+    name_converter: Optional[SchemaNameConverter],
+) -> None:
+    name_converter = name_converter or default_schema_name_converter
+
+    for type_name, graphql_type in schema.type_map.items():
+        if (
+            isinstance(graphql_type, GraphQLObjectType)
+            and type_name not in GRAPHQL_SPEC_TYPES
+        ):
+            convert_names_in_schema_object(graphql_type, name_converter)
+        if isinstance(graphql_type, GraphQLInputObjectType):
+            convert_names_in_schema_input(graphql_type, name_converter)
+
+
+def convert_names_in_schema_object(
+    graphql_type: GraphQLObjectType,
+    name_converter: SchemaNameConverter,
+) -> None:
+    for field_name, field in graphql_type.fields.items():
+        if field.args:
+            convert_names_in_schema_args(field, name_converter)
+
+        if field.resolve or field_name.lower() == field_name:
+            continue
+
+        field.resolve = resolve_to(name_converter(field_name, GraphQLField))
+
+
+def convert_names_in_schema_args(
+    graphql_type: GraphQLField,
+    name_converter: SchemaNameConverter,
+) -> None:
+    for arg_name, arg in graphql_type.args.items():
+        if arg.out_name or arg_name.lower() == arg_name:
+            continue
+
+        arg.out_name = name_converter(arg_name, GraphQLInputField)
+
+
+def convert_names_in_schema_input(
+    graphql_type: GraphQLInputObjectType,
+    name_converter: SchemaNameConverter,
+) -> None:
+    for field_name, field in graphql_type.fields.items():
+        if field.out_name or field_name.lower() == field_name:
+            continue
+
+        field.out_name = name_converter(field_name, GraphQLInputField)
+
+
+def default_schema_name_converter(graphql_name: str, _graphql_type) -> str:
+    return convert_camel_case_to_snake(graphql_name)

--- a/ariadne/schema_names.py
+++ b/ariadne/schema_names.py
@@ -45,47 +45,59 @@ def convert_schema_names(
             isinstance(graphql_type, GraphQLObjectType)
             and type_name not in GRAPHQL_SPEC_TYPES
         ):
-            convert_names_in_schema_object(graphql_type, name_converter)
+            convert_names_in_schema_object(name_converter, graphql_type, schema)
         if isinstance(graphql_type, GraphQLInputObjectType):
-            convert_names_in_schema_input(graphql_type, name_converter)
+            convert_names_in_schema_input(name_converter, graphql_type, schema)
 
 
 def convert_names_in_schema_object(
-    graphql_object: GraphQLObjectType,
     name_converter: SchemaNameConverter,
+    graphql_object: GraphQLObjectType,
+    schema: GraphQLSchema,
 ) -> None:
     for field_name, field in graphql_object.fields.items():
         if field.args:
-            convert_names_in_schema_args(graphql_object, field, name_converter)
+            convert_names_in_schema_args(
+                name_converter, field, schema, graphql_object.name, field_name
+            )
 
         if field.resolve or field_name.lower() == field_name:
             continue
 
-        field.resolve = resolve_to(name_converter(field_name, (graphql_object, field)))
+        field.resolve = resolve_to(
+            name_converter(field_name, schema, (graphql_object.name, field_name))
+        )
 
 
 def convert_names_in_schema_args(
-    graphql_object: GraphQLObjectType,
-    graphql_field: GraphQLField,
     name_converter: SchemaNameConverter,
+    graphql_field: GraphQLField,
+    schema: GraphQLSchema,
+    object_name: str,
+    field_name: str,
 ) -> None:
     for arg_name, arg in graphql_field.args.items():
         if arg.out_name or arg_name.lower() == arg_name:
             continue
 
-        arg.out_name = name_converter(arg_name, (graphql_object, graphql_field, arg))
+        arg.out_name = name_converter(
+            arg_name, schema, (object_name, field_name, arg_name)
+        )
 
 
 def convert_names_in_schema_input(
-    graphql_input: GraphQLInputObjectType,
     name_converter: SchemaNameConverter,
+    graphql_input: GraphQLInputObjectType,
+    schema: GraphQLSchema,
 ) -> None:
     for field_name, field in graphql_input.fields.items():
         if field.out_name or field_name.lower() == field_name:
             continue
 
-        field.out_name = name_converter(field_name, (graphql_input, field))
+        field.out_name = name_converter(
+            field_name, schema, (graphql_input.name, field_name)
+        )
 
 
-def default_schema_name_converter(graphql_name: str, _path) -> str:
+def default_schema_name_converter(graphql_name: str, *_) -> str:
     return convert_camel_case_to_snake(graphql_name)

--- a/ariadne/schema_names.py
+++ b/ariadne/schema_names.py
@@ -1,9 +1,7 @@
-from typing import Callable, Optional, Tuple, Union
+from typing import Callable, Optional, Tuple
 
 from graphql import (
-    GraphQLArgument,
     GraphQLField,
-    GraphQLInputField,
     GraphQLInputObjectType,
     GraphQLObjectType,
     GraphQLSchema,

--- a/ariadne/schema_names.py
+++ b/ariadne/schema_names.py
@@ -12,17 +12,7 @@ from graphql import (
 from .resolvers import resolve_to
 from .utils import convert_camel_case_to_snake
 
-SchemaNameConverter = Callable[
-    [
-        str,
-        Union[
-            Tuple[GraphQLObjectType, GraphQLField],
-            Tuple[GraphQLObjectType, GraphQLField, GraphQLArgument],
-            Tuple[GraphQLInputObjectType, GraphQLInputField],
-        ],
-    ],
-    str,
-]
+SchemaNameConverter = Callable[[str, GraphQLSchema, Tuple[str, ...]], str]
 
 GRAPHQL_SPEC_TYPES = (
     "__Directive",

--- a/tests/test_schema_names_conversion.py
+++ b/tests/test_schema_names_conversion.py
@@ -115,6 +115,38 @@ def test_inputs_field_names_are_converted():
     assert input_type.fields["convertedField"].out_name == "converted_field"
 
 
+def test_inputs_converted_fields_names_are_used():
+    type_defs = gql(
+        """
+        type Query {
+            test(input: TestInput): String
+        }
+
+        input TestInput {
+            field: String
+            convertedField: String
+        }
+        """
+    )
+
+    query_type = QueryType()
+    
+    
+    @query_type.field("test")
+    def resolve_test(*_, input=None):
+        return input["field"] + input["convertedField"]
+
+
+    schema = make_executable_schema(type_defs, query_type, convert_names_case=True)
+
+    result = graphql_sync(
+        schema,
+        '{ test(input: { field: "Lorem", convertedField: "Ipsum"}) }'
+    )
+
+    assert result.data == {"test": "LoremIpsum"}
+
+
 def custom_converter(graphql_name, path):
     assert path
     return f"custom_{graphql_name}"

--- a/tests/test_schema_names_conversion.py
+++ b/tests/test_schema_names_conversion.py
@@ -165,8 +165,10 @@ def test_inputs_converted_fields_names_are_used():
     assert result.data == {"test": "LoremIpsum"}
 
 
-def custom_converter(graphql_name, path):
+def custom_converter(graphql_name, schema, path):
+    assert schema
     assert path
+    assert path[-1] == graphql_name
     return f"custom_{graphql_name}"
 
 

--- a/tests/test_schema_names_conversion.py
+++ b/tests/test_schema_names_conversion.py
@@ -137,6 +137,7 @@ def test_fields_converted_argument_names_are_used():
 
 
 def test_inputs_converted_fields_names_are_used():
+    # pylint: disable=redefined-builtin
     type_defs = gql(
         """
         type Query {

--- a/tests/test_schema_names_conversion.py
+++ b/tests/test_schema_names_conversion.py
@@ -1,0 +1,191 @@
+from graphql import graphql_sync
+
+from ariadne import QueryType, gql, make_executable_schema
+
+
+def test_field_names_without_resolvers_are_converted():
+    type_defs = gql(
+        """
+        type Query {
+            field: String
+            convertedField: String
+        }
+        """
+    )
+
+    schema = make_executable_schema(type_defs, convert_names_case=True)
+    result = graphql_sync(
+        schema,
+        "{ field convertedField }",
+        root_value={
+            "field": "works",
+            "converted_field": "okay",
+        },
+    )
+
+    assert result.data == {"field": "works", "convertedField": "okay"}
+
+
+def test_field_names_with_resolvers_are_not_converted():
+    type_defs = gql(
+        """
+        type Query {
+            field: String
+            convertedField: String
+        }
+        """
+    )
+
+    query_type = QueryType()
+    query_type.set_field("convertedField", lambda *_: "lambda")
+
+    schema = make_executable_schema(type_defs, query_type, convert_names_case=True)
+    result = graphql_sync(
+        schema,
+        "{ field convertedField }",
+        root_value={
+            "field": "works",
+            "converted_field": "okay",
+        },
+    )
+
+    assert result.data == {"field": "works", "convertedField": "lambda"}
+
+
+def test_field_names_without_need_for_conversion_are_skipped():
+    type_defs = gql(
+        """
+        type Query {
+            field: String
+            convertedField: String
+        }
+        """
+    )
+
+    schema = make_executable_schema(type_defs, convert_names_case=True)
+    assert schema.type_map["Query"].fields["field"].resolve is None
+    assert schema.type_map["Query"].fields["convertedField"].resolve is not None
+
+
+def test_fields_arguments_are_converted():
+    type_defs = gql(
+        """
+        type Query {
+            field(arg: String, otherArg: Int): String
+            convertedField(arg: String, otherArg: Int): String
+        }
+        """
+    )
+
+    schema = make_executable_schema(type_defs, convert_names_case=True)
+    query_type = schema.type_map["Query"]
+    field = query_type.fields["field"]
+    converted_field = query_type.fields["convertedField"]
+
+    # Args that don't need conversion are skipped
+    assert field.args["arg"].out_name is None
+    assert converted_field.args["arg"].out_name is None
+
+    # Input field names that need conversion have out_name set
+    assert field.args["otherArg"].out_name == "other_arg"
+    assert converted_field.args["otherArg"].out_name == "other_arg"
+
+
+def test_inputs_field_names_are_converted():
+    type_defs = gql(
+        """
+        type Query {
+            _skip: String
+        }
+
+        input Test {
+            field: String
+            convertedField: String
+        }
+        """
+    )
+
+    schema = make_executable_schema(type_defs, convert_names_case=True)
+    input_type = schema.type_map["Test"]
+
+    # Input field names that don't need conversion are skipped
+    assert input_type.fields["field"].out_name is None
+
+    # Input field names that need conversion have out_name set
+    assert input_type.fields["convertedField"].out_name == "converted_field"
+
+
+def custom_converter(graphql_name, path):
+    assert path
+    return f"custom_{graphql_name}"
+
+
+def test_field_names_are_converted_using_custom_strategy():
+    type_defs = gql(
+        """
+        type Query {
+            field: String
+            convertedField: String
+        }
+        """
+    )
+
+    schema = make_executable_schema(type_defs, convert_names_case=custom_converter)
+    result = graphql_sync(
+        schema,
+        "{ field convertedField }",
+        root_value={
+            "field": "works",
+            "custom_convertedField": "okay",
+        },
+    )
+
+    assert result.data == {"field": "works", "convertedField": "okay"}
+
+
+def test_field_arguments_are_converted_using_custom_strategy():
+    type_defs = gql(
+        """
+        type Query {
+            field(arg: String, otherArg: Int): String
+            convertedField(arg: String, otherArg: Int): String
+        }
+        """
+    )
+
+    schema = make_executable_schema(type_defs, convert_names_case=custom_converter)
+    query_type = schema.type_map["Query"]
+    field = query_type.fields["field"]
+    converted_field = query_type.fields["convertedField"]
+
+    # Args that don't need conversion are skipped
+    assert field.args["arg"].out_name is None
+    assert converted_field.args["arg"].out_name is None
+
+    # Input field names that need conversion have out_name set
+    assert field.args["otherArg"].out_name == "custom_otherArg"
+    assert converted_field.args["otherArg"].out_name == "custom_otherArg"
+
+
+def test_inputs_field_names_are_converted_using_custom_strategy():
+    type_defs = gql(
+        """
+        type Query {
+            _skip: String
+        }
+
+        input Test {
+            field: String
+            convertedField: String
+        }
+        """
+    )
+
+    schema = make_executable_schema(type_defs, convert_names_case=custom_converter)
+    input_type = schema.type_map["Test"]
+
+    # Input field names that don't need conversion are skipped
+    assert input_type.fields["field"].out_name is None
+
+    # Input field names that need conversion have out_name set
+    assert input_type.fields["convertedField"].out_name == "custom_convertedField"

--- a/tests/test_schema_names_conversion.py
+++ b/tests/test_schema_names_conversion.py
@@ -115,6 +115,27 @@ def test_inputs_field_names_are_converted():
     assert input_type.fields["convertedField"].out_name == "converted_field"
 
 
+def test_fields_converted_argument_names_are_used():
+    type_defs = gql(
+        """
+        type Query {
+            test(arg: String, otherArg: String): String
+        }
+        """
+    )
+
+    query_type = QueryType()
+
+    @query_type.field("test")
+    def resolve_test(*_, arg=None, other_arg=None):
+        return arg + other_arg
+
+    schema = make_executable_schema(type_defs, query_type, convert_names_case=True)
+
+    result = graphql_sync(schema, '{ test(arg: "Lorem", otherArg: "Ipsum") }')
+    assert result.data == {"test": "LoremIpsum"}
+
+
 def test_inputs_converted_fields_names_are_used():
     type_defs = gql(
         """
@@ -130,20 +151,16 @@ def test_inputs_converted_fields_names_are_used():
     )
 
     query_type = QueryType()
-    
-    
+
     @query_type.field("test")
     def resolve_test(*_, input=None):
-        return input["field"] + input["convertedField"]
-
+        return input["field"] + input["converted_field"]
 
     schema = make_executable_schema(type_defs, query_type, convert_names_case=True)
 
     result = graphql_sync(
-        schema,
-        '{ test(input: { field: "Lorem", convertedField: "Ipsum"}) }'
+        schema, '{ test(input: { field: "Lorem", convertedField: "Ipsum"}) }'
     )
-
     assert result.data == {"test": "LoremIpsum"}
 
 


### PR DESCRIPTION
Supersedes #905

Adds `convert_names_case` to `make_executable_schema`. This option accepts bool or callable:

If `convert_names_case` is set to `True`, `make_executable_schema` will walk the schema:

- For fields without resolver, new resolver will be set that converts field's name to python case using `convert_camel_case_to_snake`. Eg. `userName` will be resolved to `user_name`.
- For input fields `out_name` will be set from its name, meaning that `isClosed` field will be stored on `is_closed` dictionary key passed to resolver 
- For arguments `out_name`  will be set from argument name, meaning that `sendWelcomeEmail: bool` argument's value will be passed to `send_welcome_email` resolver's kwarg.

If `convert_names_case` is a function, `make_executable_schema` will walk the schema:

- For fields without resolver, `convert_names_case` will be called with GraphQL name as first argument, schema as second and tuple with path to schema item as third arguments. This function will have to return a name to resolve to by default resolver.
-  For input fields, `convert_names_case` with field's name as first argument, schema as second and tuple with path to schema item as third arguments. This function will have to return a key name to put input's value for field in python dict.
-  For fields arguments, `convert_names_case` with field's name as first argument, schema as second and tuple with path to schema item as third arguments. This function will have to return a python kwarg name to put input's value for field argument.

Example custom converter signature is:

```python
def convert_names(graphql_name: str, schema: GraphQLSchema, path: Tuple[str, ...]) -> str
    return graphql_name
```