### PR TITLE
Add context value backward compat

### DIFF
--- a/ariadne/asgi/handlers/base.py
+++ b/ariadne/asgi/handlers/base.py
@@ -20,6 +20,7 @@ from ...types import (
     RootValue,
     ValidationRules,
 )
+from ...utils import context_value_one_arg_deprecated
 
 
 class GraphQLHandler(ABC):
@@ -119,7 +120,12 @@ class GraphQLHandler(ABC):
         `data`: a GraphQL data from connection.
         """
         if callable(self.context_value):
-            context = self.context_value(request, data)  # type: ignore
+            try:
+                context = self.context_value(request, data)  # type: ignore
+            except TypeError:  # TODO: remove in 0.19
+                context_value_one_arg_deprecated()
+                context = self.context_value(request)  # type: ignore
+
             if isawaitable(context):
                 context = await context
             return context

--- a/ariadne/utils.py
+++ b/ariadne/utils.py
@@ -2,6 +2,7 @@ import asyncio
 from collections.abc import Mapping
 from functools import wraps
 from typing import Optional, Union, Callable, Dict, Any, cast
+from warnings import warn
 
 from graphql.language import DocumentNode, OperationDefinitionNode, OperationType
 from graphql import GraphQLError, GraphQLType, parse
@@ -239,3 +240,13 @@ def get_operation_type(
             if isinstance(definition, OperationDefinitionNode):
                 return definition.operation
     raise RuntimeError("Can't get GraphQL operation type")
+
+
+def context_value_one_arg_deprecated():  # TODO: remove in 0.19
+    warn(
+        "'root_value(context, document)' has been deprecated and will raise a type "
+        "error in Ariadne 0.18, update definition to "
+        "'root_value(context, operation_name, variables, document)'.",
+        DeprecationWarning,
+        stacklevel=2,
+    )

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -34,6 +34,7 @@ from .types import (
     RootValue,
     ValidationRules,
 )
+from .utils import context_value_one_arg_deprecated
 
 try:
     from multipart import parse_form
@@ -430,7 +431,11 @@ class GraphQL:
         `data`: a GraphQL data.
         """
         if callable(self.context_value):
-            return self.context_value(environ, data)  # type: ignore
+            try:
+                return self.context_value(environ, data)  # type: ignore
+            except TypeError:  # TODO: remove in 0.19
+                context_value_one_arg_deprecated()
+                return self.context_value(environ)  # type: ignore
         return self.context_value or {"request": environ}
 
     def get_extensions_for_request(

--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -53,6 +53,21 @@ def test_async_context_value_function_result_is_awaited_before_passing_to_resolv
     assert response.json() == {"data": {"testContext": "TEST-ASYNC-CONTEXT"}}
 
 
+def test_custom_deprecated_context_value_function_raises_warning_by_query(
+    schema,
+):
+    def get_context_value(request):
+        return {"request": request, }
+
+    app = GraphQL(
+        schema, context_value=get_context_value
+    )
+    client = TestClient(app)
+
+    with pytest.deprecated_call():
+        client.post("/", json={"query": "{ status }"})
+
+
 def test_custom_root_value_is_passed_to_query_resolvers(schema):
     app = GraphQL(schema, root_value={"test": "TEST-ROOT"})
     client = TestClient(app)

--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -57,11 +57,9 @@ def test_custom_deprecated_context_value_function_raises_warning_by_query(
     schema,
 ):
     def get_context_value(request):
-        return {"request": request, }
+        return {"request": request}
 
-    app = GraphQL(
-        schema, context_value=get_context_value
-    )
+    app = GraphQL(schema, context_value=get_context_value)
     client = TestClient(app)
 
     with pytest.deprecated_call():

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -57,6 +57,20 @@ def test_custom_context_value_function_result_is_passed_to_resolvers(schema):
     assert result == {"data": {"testContext": "TEST-CONTEXT"}}
 
 
+def test_warning_is_raised_if_custom_context_value_function_has_deprecated_signature(
+    schema,
+):
+    def get_context_value(request):
+        return {"request": request}
+
+    app = GraphQL(
+        schema, context_value=get_context_value
+    )
+
+    with pytest.deprecated_call():
+        app.execute_query({}, {"query": "{ status }"})
+
+
 def test_custom_root_value_is_passed_to_resolvers(schema):
     app = GraphQL(schema, root_value={"test": "TEST-ROOT"})
     _, result = app.execute_query({}, {"query": "{ testRoot }"})

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -63,9 +63,7 @@ def test_warning_is_raised_if_custom_context_value_function_has_deprecated_signa
     def get_context_value(request):
         return {"request": request}
 
-    app = GraphQL(
-        schema, context_value=get_context_value
-    )
+    app = GraphQL(schema, context_value=get_context_value)
 
     with pytest.deprecated_call():
         app.execute_query({}, {"query": "{ status }"})


### PR DESCRIPTION
Ariadne 0.18 changes API for `context_value` and `root_value` functions. While `root_value` has backwards-compatibility layer that catches and raises warning for outdated functions. Same is not the case for `context_value`. This PR changes that.