### PR TITLE
Add xfail to ws connection init timeout test

### DIFF
--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -671,7 +671,7 @@ def test_init_wait_timeout_graphql_transport_ws(
             ws.receive_json()
 
 
-@pytest.mark.xfail(reason="this test sometimes fails due to race condition")
+@pytest.mark.xfail(reason="sometimes fails due to a race condition")
 def test_handle_connection_init_timeout_handler_executed_graphql_transport_ws(
     schema,
 ):

--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -671,7 +671,7 @@ def test_init_wait_timeout_graphql_transport_ws(
             ws.receive_json()
 
 
-@pytest.xfail(reason="this test sometimes fails due to race condition")
+@pytest.mark.xfail(reason="this test sometimes fails due to race condition")
 def test_handle_connection_init_timeout_handler_executed_graphql_transport_ws(
     schema,
 ):

--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -671,6 +671,7 @@ def test_init_wait_timeout_graphql_transport_ws(
             ws.receive_json()
 
 
+@pytest.xfail(reason="this test sometimes fails due to race condition")
 def test_handle_connection_init_timeout_handler_executed_graphql_transport_ws(
     schema,
 ):


### PR DESCRIPTION
Our tests ocasionally fail due to race condition in `test_handle_connection_init_timeout_handler_executed_graphql_transport_ws`. I'll open an issue for this later, but in the meantime I would like to make this test don't fail the suite when fail happens.