### PR TITLE
Fix federation support for directives without surrounding whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added support for passing `Enum` types directly to `make_executable_schema`
 - Added `convert_names_case` option to `make_federated_schema`.
 - Added support for the `@interfaceObject` directive in Apollo Federation.
+- Fixed federation support for directives without surrounding whitespace.
 
 
 ## 0.18.1 (2023-02-22)

--- a/ariadne/contrib/federation/utils.py
+++ b/ariadne/contrib/federation/utils.py
@@ -23,8 +23,9 @@ _i_token_description_single_line = r"(?:\"(?:[^\"\n\r])*?\")"
 
 _r_directive_definition = re.compile(
     "("
-    f"{_i_token_delimiter}"
-    f"(?:{_i_token_description_block_string}|{_i_token_description_single_line})??"
+    f"(?:{_i_token_delimiter}(?:"
+    f"{_i_token_description_block_string}|{_i_token_description_single_line}"
+    "))??"
     f"{_i_token_delimiter}directive"
     f"(?:{_i_token_delimiter})?@({_i_token_name})"
     f"(?:(?:{_i_token_delimiter})?{_i_token_arguments})?"

--- a/tests/federation/test_utils.py
+++ b/tests/federation/test_utils.py
@@ -121,6 +121,12 @@ def test_purge_directives_remove_custom_directives_with_single_line_description(
     )
 
 
+def test_purge_directives_without_leading_whitespace():
+    type_defs = "#\ndirective @custom on FIELD"
+
+    assert sic(purge_schema_directives(type_defs)) == ""
+
+
 def test_get_entity_types_with_key_directive():
     type_defs = """
         type Query {


### PR DESCRIPTION
As written, this regex requires two delimiters before a `directive @custom on FIELD` definition. In some cases (for example, when the preceding line is a comment), this causes `purge_schema_directives` to remove only the `@custom` part, leaving `directive on FIELD` which causes downstream parsing errors.

The solution is to require the second delimiter only if the description is also present.