### PR TITLE
fix: include GraphQL files in `hatch.build` config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## Next (UNRELEASED)
+- Fixed `.graphql` definitions files not being included in the dist files
+
 ## 0.19.0 (2023-03-27)
 
 - Added `InputType` for setting Python representations of GraphQL Input types

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ tracing = ["opentracing"]
 include = [
   "ariadne/**/*.py",
   "ariadne/**/*.html",
+  "ariadne/**/*.graphql",
   "ariadne/py.typed",
   "LICENSE",
   "README.md",


### PR DESCRIPTION
### Description
* In the last version (`0.19.0`) we've introduced `*.graphql` files (that are storing the federation definitions per spec version), but they are not included in the `.tar.gz` and `.whl` distribution files. This PR fixes that.
* Tested this locally and the missing files are now part of the dist files.
* @rafalp, please let me know if you want us to be specific with the path, so instead to have `ariadne/contrib/federation/definitions/*.graphql`