### PR TITLE
Make query validator configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.19.2 (UNRELEASED)
+## 0.20 (UNRELEASED)
 - Added `query_validator` option to ASGI and WSGI `GraphQL` applications that enables query validation customization.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.20 (UNRELEASED)
-- Added `query_validator` option to ASGI and WSGI `GraphQL` applications that enables query validation customization.
+- Added `query_validator` option to ASGI and WSGI `GraphQL` applications that enables customization of query validation step.
 
 
 ## 0.19.1 (2023-03-28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.19.2 (UNRELEASED)
+- Added `query_validator` option to ASGI and WSGI `GraphQL` applications that enables query validation customization.
+
+
 ## 0.19.1 (2023-03-28)
 - Fixed `.graphql` definitions files not being included in the dist files
 

--- a/ariadne/asgi/graphql.py
+++ b/ariadne/asgi/graphql.py
@@ -12,6 +12,7 @@ from ..types import (
     ContextValue,
     ErrorFormatter,
     QueryParser,
+    QueryValidator,
     RootValue,
     ValidationRules,
 )
@@ -36,6 +37,7 @@ class GraphQL:
         context_value: Optional[ContextValue] = None,
         root_value: Optional[RootValue] = None,
         query_parser: Optional[QueryParser] = None,
+        query_validator: Optional[QueryValidator] = None,
         validation_rules: Optional[ValidationRules] = None,
         debug: bool = False,
         introspection: bool = True,
@@ -63,6 +65,9 @@ class GraphQL:
 
         `query_parser`: a `QueryParser` to use by this server. Defaults to
         `graphql.parse`.
+
+        `query_validator`: a `QueryValidator` to use by this server. Defaults to
+        `graphql.validate`.
 
         `validation_rules`: a `ValidationRules` list or callable returning a
         list of extra validation rules server should use to validate the
@@ -119,6 +124,7 @@ class GraphQL:
             context_value,
             root_value,
             query_parser,
+            query_validator,
             validation_rules,
             debug,
             introspection,
@@ -132,6 +138,7 @@ class GraphQL:
             context_value,
             root_value,
             query_parser,
+            query_validator,
             validation_rules,
             debug,
             introspection,

--- a/ariadne/asgi/handlers/base.py
+++ b/ariadne/asgi/handlers/base.py
@@ -17,6 +17,7 @@ from ...types import (
     OnDisconnect,
     OnOperation,
     QueryParser,
+    QueryValidator,
     RootValue,
     ValidationRules,
 )
@@ -37,6 +38,7 @@ class GraphQLHandler(ABC):
         self.logger: Union[None, str, Logger, LoggerAdapter] = None
         self.root_value: Optional[RootValue] = None
         self.query_parser: Optional[QueryParser] = None
+        self.query_validator: Optional[QueryValidator] = None
         self.validation_rules: Optional[ValidationRules] = None
         self.execution_context_class: Optional[Type[ExecutionContext]] = None
         self.middleware_manager_class: Optional[Type[MiddlewareManager]] = None
@@ -75,6 +77,7 @@ class GraphQLHandler(ABC):
         context_value: Optional[ContextValue] = None,
         root_value: Optional[RootValue] = None,
         query_parser: Optional[QueryParser] = None,
+        query_validator: Optional[QueryValidator] = None,
         validation_rules: Optional[ValidationRules] = None,
         debug: bool = False,
         introspection: bool = True,
@@ -96,6 +99,7 @@ class GraphQLHandler(ABC):
         self.explorer = explorer
         self.logger = logger
         self.query_parser = query_parser
+        self.query_validator = query_validator
         self.root_value = root_value
         self.schema = schema
         self.validation_rules = validation_rules

--- a/ariadne/asgi/handlers/graphql_transport_ws.py
+++ b/ariadne/asgi/handlers/graphql_transport_ws.py
@@ -343,6 +343,7 @@ class GraphQLTransportWSHandler(GraphQLWebsocketHandler):
                 context_value=context_value,
                 root_value=self.root_value,
                 query_document=query_document,
+                query_validator=self.query_validator,
                 validation_rules=self.validation_rules,
                 debug=self.debug,
                 introspection=self.introspection,

--- a/ariadne/asgi/handlers/graphql_ws.py
+++ b/ariadne/asgi/handlers/graphql_ws.py
@@ -301,6 +301,7 @@ class GraphQLWSHandler(GraphQLWebsocketHandler):
             context_value=context_value,
             root_value=self.root_value,
             query_document=query_document,
+            query_validator=self.query_validator,
             validation_rules=self.validation_rules,
             debug=self.debug,
             introspection=self.introspection,

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -281,6 +281,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
             context_value=context_value,
             root_value=self.root_value,
             query_parser=self.query_parser,
+            query_validator=self.query_validator,
             query_document=query_document,
             validation_rules=self.validation_rules,
             debug=self.debug,

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -22,6 +22,7 @@ from graphql import (
     GraphQLResolveInfo,
     GraphQLSchema,
 )
+from graphql.utilities.type_info import TypeInfo
 from graphql.validation.rules import ASTValidationRule
 
 from starlette.websockets import WebSocket
@@ -35,6 +36,7 @@ __all__ = [
     "ContextValue",
     "RootValue",
     "QueryParser",
+    "QueryValidator",
     "ValidationRules",
     "ExtensionList",
     "Extensions",
@@ -299,6 +301,66 @@ allowed_queries_parser.add_query(
 ```
 """
 QueryParser = Callable[[ContextValue, Dict[str, Any]], DocumentNode]
+
+"""Type of `query_validator` option of GraphQL servers.
+
+Enables customization of server's GraphQL query validation logic. If not set or `None`, 
+default validate is used instead.
+
+# Default query validator
+
+Default query validator used by Ariadne is `validate` function from the `graphql` 
+package.
+
+# Custom validator
+
+Custom validator is a function or callable accepting up to 5 arguments:
+
+`schema`: GraphQLSchema for the graphql schema
+`document_ast`: DocumentNode result of query parser
+`rules`: optional list of AST validation rules of type ASTValidationRule
+`max_errors`: optional maximum number of errors to return
+`type_info`: optional type info, pending deprecation in graphql 3.3
+
+Validator is required to return `List[GraphQLError]` which should be empty
+if there were no errors found
+
+# Example validator
+
+Below code defines custom validator that mutates same Document with a flag to "memoize" validation
+(this works best in a tandem with a memoized parser for end-to-end memoization
+ of parsing and validation):
+
+```python
+from graphql import GraphQLError, validate
+
+
+class MemoizedQueriesValidator:
+    def __call__(self, schema, document_ast, *args, **kwargs):
+        past_validation = getattr(document_ast, "_past_validation", None)
+        if past_validation:
+            return past_validation
+        validation = validate(schema, document_ast, *args, **kwargs)
+        setattr(document_ast, "_past_validation", validation)
+        return validation
+
+
+memoized_queries_validator = MemoizedQueriesValidator()
+```
+"""
+
+
+class QueryValidator(Protocol):
+    def __call__(
+        self,
+        schema: GraphQLSchema,
+        document_ast: DocumentNode,
+        rules: Optional[Collection[Type[ASTValidationRule]]] = None,
+        max_errors: Optional[int] = None,
+        type_info: Optional[TypeInfo] = None,
+    ) -> List[GraphQLError]:
+        ...
+
 
 """Type of `validation_rules` option of GraphQL servers.
 

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -31,6 +31,7 @@ from .types import (
     GraphQLResult,
     MiddlewareList,
     QueryParser,
+    QueryValidator,
     RootValue,
     ValidationRules,
 )
@@ -67,6 +68,7 @@ class GraphQL:
         context_value: Optional[ContextValue] = None,
         root_value: Optional[RootValue] = None,
         query_parser: Optional[QueryParser] = None,
+        query_validator: Optional[QueryValidator] = None,
         validation_rules: Optional[ValidationRules] = None,
         debug: bool = False,
         introspection: bool = True,
@@ -95,6 +97,9 @@ class GraphQL:
 
         `query_parser`: a `QueryParser` to use by this server. Defaults to
         `graphql.parse`.
+
+        `query_validator`: a `QueryValidator` to use by this server. Defaults to
+        `graphql.validate`.
 
         `validation_rules`: a `ValidationRules` list or callable returning a
         list of extra validation rules server should use to validate the
@@ -141,6 +146,7 @@ class GraphQL:
         self.context_value = context_value
         self.root_value = root_value
         self.query_parser = query_parser
+        self.query_validator = query_validator
         self.validation_rules = validation_rules
         self.debug = debug
         self.introspection = introspection
@@ -405,6 +411,7 @@ class GraphQL:
             context_value=context_value,
             root_value=self.root_value,
             query_parser=self.query_parser,
+            query_validator=self.query_validator,
             validation_rules=self.validation_rules,
             debug=self.debug,
             introspection=self.introspection,

--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -4,7 +4,10 @@ from datetime import timedelta
 from unittest.mock import ANY, Mock
 
 import pytest
-from graphql import parse
+from graphql import (
+    GraphQLError,
+    parse,
+)
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 
@@ -260,6 +263,25 @@ def test_custom_query_parser_is_used_for_http_query(schema):
     response = client.post("/", json={"query": "{ testContext }"})
     assert response.json() == {"data": {"status": True}}
     mock_parser.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("errors"),
+    [
+        ([]),
+        ([GraphQLError("Nope")]),
+    ],
+)
+def test_custom_query_validator_is_used_for_http_query_error(schema, errors):
+    mock_validator = Mock(return_value=errors)
+    app = GraphQL(schema, query_validator=mock_validator)
+    client = TestClient(app)
+    response = client.post("/", json={"query": "{ testContext }"})
+    if errors:
+        assert response.json() == {"errors": [{"message": "Nope"}]}
+    else:
+        assert response.json() == {"data": {"testContext": None}}
+    mock_validator.assert_called_once()
 
 
 def test_custom_validation_rule_is_called_by_query_validation(

--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -4,10 +4,7 @@ from datetime import timedelta
 from unittest.mock import ANY, Mock
 
 import pytest
-from graphql import (
-    GraphQLError,
-    parse,
-)
+from graphql import GraphQLError, parse
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect
 

--- a/tests/asgi/test_websockets_graphql_transport_ws.py
+++ b/tests/asgi/test_websockets_graphql_transport_ws.py
@@ -2,10 +2,7 @@
 from unittest.mock import Mock
 
 import pytest
-from graphql import (
-    parse,
-    GraphQLError,
-)
+from graphql import parse, GraphQLError
 from graphql.language import OperationType
 from starlette.testclient import TestClient
 from starlette.websockets import WebSocketDisconnect

--- a/tests/asgi/test_websockets_graphql_ws.py
+++ b/tests/asgi/test_websockets_graphql_ws.py
@@ -2,10 +2,7 @@
 from unittest.mock import Mock
 
 import pytest
-from graphql import (
-    parse,
-    GraphQLError,
-)
+from graphql import parse, GraphQLError
 from starlette.testclient import TestClient
 
 from ariadne.asgi import GraphQL

--- a/tests/asgi/test_websockets_graphql_ws.py
+++ b/tests/asgi/test_websockets_graphql_ws.py
@@ -2,7 +2,10 @@
 from unittest.mock import Mock
 
 import pytest
-from graphql import parse
+from graphql import (
+    parse,
+    GraphQLError,
+)
 from starlette.testclient import TestClient
 
 from ariadne.asgi import GraphQL
@@ -168,6 +171,51 @@ def test_custom_query_parser_is_used_for_subscription_over_websocket(
         ws.send_json({"type": GraphQLWSHandler.GQL_CONNECTION_TERMINATE})
 
 
+@pytest.mark.parametrize(
+    ("errors"),
+    [
+        ([]),
+        ([GraphQLError("Nope")]),
+    ],
+)
+def test_custom_query_validator_is_used_for_subscription_over_websocket(schema, errors):
+    mock_validator = Mock(return_value=errors)
+    websocket_handler = GraphQLWSHandler()
+    app = GraphQL(
+        schema,
+        query_validator=mock_validator,
+        context_value={"test": "I'm context"},
+        root_value={"test": "I'm root"},
+        websocket_handler=websocket_handler,
+    )
+
+    with TestClient(app).websocket_connect("/", ["graphql-ws"]) as ws:
+        ws.send_json({"type": GraphQLWSHandler.GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GraphQLWSHandler.GQL_CONNECTION_ACK
+        ws.send_json(
+            {
+                "type": GraphQLWSHandler.GQL_START,
+                "id": "test2",
+                "payload": {
+                    "operationName": None,
+                    "query": "subscription { testRoot }",
+                    "variables": None,
+                },
+            }
+        )
+        response = ws.receive_json()
+        if not errors:
+            assert response["type"] == GraphQLWSHandler.GQL_DATA
+            assert response["id"] == "test2"
+            assert response["payload"]["data"] == {"testRoot": "I'm root"}
+        else:
+            assert response["type"] == GraphQLWSHandler.GQL_ERROR
+            assert response["id"] == "test2"
+            assert response["payload"]["message"] == "Nope"
+        ws.send_json({"type": GraphQLWSHandler.GQL_CONNECTION_TERMINATE})
+
+
 def test_custom_query_parser_is_used_for_query_over_websocket(
     schema,
 ):
@@ -200,6 +248,51 @@ def test_custom_query_parser_is_used_for_query_over_websocket(
         assert response["type"] == GraphQLWSHandler.GQL_DATA
         assert response["id"] == "test2"
         assert response["payload"]["data"] == {"testContext": "I'm context"}
+        ws.send_json({"type": GraphQLWSHandler.GQL_CONNECTION_TERMINATE})
+
+
+@pytest.mark.parametrize(
+    ("errors"),
+    [
+        ([]),
+        ([GraphQLError("Nope")]),
+    ],
+)
+def test_custom_query_validator_is_used_for_query_over_websocket(schema, errors):
+    mock_validator = Mock(return_value=errors)
+    websocket_handler = GraphQLWSHandler()
+    app = GraphQL(
+        schema,
+        query_validator=mock_validator,
+        context_value={"test": "I'm context"},
+        root_value={"test": "I'm root"},
+        websocket_handler=websocket_handler,
+    )
+
+    with TestClient(app).websocket_connect("/", ["graphql-ws"]) as ws:
+        ws.send_json({"type": GraphQLWSHandler.GQL_CONNECTION_INIT})
+        response = ws.receive_json()
+        assert response["type"] == GraphQLWSHandler.GQL_CONNECTION_ACK
+        ws.send_json(
+            {
+                "type": GraphQLWSHandler.GQL_START,
+                "id": "test2",
+                "payload": {
+                    "operationName": None,
+                    "query": "query { testRoot }",
+                    "variables": None,
+                },
+            }
+        )
+        response = ws.receive_json()
+        if errors:
+            assert response["type"] == GraphQLWSHandler.GQL_DATA
+            assert response["id"] == "test2"
+            assert response["payload"]["errors"] == [{"message": "Nope"}]
+        else:
+            assert response["type"] == GraphQLWSHandler.GQL_DATA
+            assert response["id"] == "test2"
+            assert response["payload"]["data"] == {"testRoot": "I'm root"}
         ws.send_json({"type": GraphQLWSHandler.GQL_CONNECTION_TERMINATE})
 
 


### PR DESCRIPTION
Please consider this small contribution made in the footsteps of https://github.com/mirumee/ariadne/pull/977. The general idea is that validation can equally benefit from customization to achieve for example memoization as it can get quite expensive for large queries under high QPS. Currently this is not possible without patching ariadne/graphql validate functions. There could have been perhaps a higher level abstraction to memoize both parsing and validation in a single step, but given present semantics this seems more appropriate.

This PR adds query_validator option to the WSGI and ASGI GraphQL applications. This feature opens gate to implementing custom base query validator that (for example) allows to cache validation of query documents.