### PR TITLE
Fix error message invalid payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # CHANGELOG
 
 ## 0.20 (UNRELEASED)
+
 - Added `query_validator` option to ASGI and WSGI `GraphQL` applications that enables customization of query validation step.
+- Fixed `ERROR` message in GraphQL-WS protocol having invalid payload type.
 
 
 ## 0.19.1 (2023-03-28)
+
 - Fixed `.graphql` definitions files not being included in the dist files
 
 

--- a/ariadne/asgi/handlers/graphql_transport_ws.py
+++ b/ariadne/asgi/handlers/graphql_transport_ws.py
@@ -326,7 +326,7 @@ class GraphQLTransportWSHandler(GraphQLWebsocketHandler):
                 {
                     "type": GraphQLTransportWSHandler.GQL_ERROR,
                     "id": operation_id,
-                    "payload": self.error_formatter(error, self.debug),
+                    "payload": [self.error_formatter(error, self.debug)],
                 }
             )
             return
@@ -375,7 +375,7 @@ class GraphQLTransportWSHandler(GraphQLWebsocketHandler):
                 {
                     "type": GraphQLTransportWSHandler.GQL_ERROR,
                     "id": operation_id,
-                    "payload": results_producer[0],
+                    "payload": [results_producer[0]],
                 }
             )
         else:

--- a/tests/asgi/snapshots/snap_test_query_execution.py
+++ b/tests/asgi/snapshots/snap_test_query_execution.py
@@ -73,15 +73,17 @@ snapshots['test_attempt_execute_subscription_with_invalid_query_returns_error_js
     'message': "Cannot query field 'error' on type 'Subscription'."
 }
 
-snapshots['test_attempt_execute_subscription_with_invalid_query_returns_error_json_graphql_transport_ws 1'] = {
-    'locations': [
-        {
-            'column': 16,
-            'line': 1
-        }
-    ],
-    'message': "Cannot query field 'error' on type 'Subscription'."
-}
+snapshots['test_attempt_execute_subscription_with_invalid_query_returns_error_json_graphql_transport_ws 1'] = [
+    {
+        'locations': [
+            {
+                'column': 16,
+                'line': 1
+            }
+        ],
+        'message': "Cannot query field 'error' on type 'Subscription'."
+    }
+]
 
 snapshots['test_complex_query_is_executed_for_post_json_request 1'] = {
     'data': {

--- a/tests/asgi/test_websockets_graphql_transport_ws.py
+++ b/tests/asgi/test_websockets_graphql_transport_ws.py
@@ -236,7 +236,7 @@ def test_custom_query_validator_is_used_for_subscription_over_websocket_transpor
         else:
             assert response["type"] == GraphQLTransportWSHandler.GQL_ERROR
             assert response["id"] == "test2"
-            assert response["payload"]["message"] == "Nope"
+            assert response["payload"][0]["message"] == "Nope"
 
 
 def test_custom_query_parser_is_used_for_query_over_websocket_transport_ws(


### PR DESCRIPTION
`payload` attribute of `ERROR` message in `graphql-ws` should be list of errors, not an error.

Fixes #1053