### PR TITLE
Run benchmarks only on demand

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,8 +4,8 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron:  "0 7 * * 1"
+    tags:
+      - benchmark-**
 
 jobs:
   build:


### PR DESCRIPTION
Changes benchmarks so they are only ran on demand. To trigger benchmarks you need to create "benchmark-" tag.