### PR TITLE
Remove Python 3.7 support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.10
+    - name: Set up Python 3.11
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - name: Install pypa/build
       run: >-
         python -m

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -48,7 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         library: ["fastapi", "starlette", "flask"]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Removed `ApolloTracingSync`. `ApolloTracing` now supports both async and sync contexts.
 - Added `OpenTelemetry` and `opentelemetry_extension` extension, importable form `ariadne.tracing.opentelemetry`.
 - Updated default GraphiQL2 template to use production build of React.js.
+- Dropped support for Python 3.7.
 
 
 ## 0.19.1 (2023-03-28)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
   "License :: OSI Approved :: BSD License",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 from aiodataloader import DataLoader as AsyncDataLoader
 

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -3,14 +3,9 @@ import sys
 import pytest
 from aiodataloader import DataLoader as AsyncDataLoader
 
+from graphql_sync_dataloaders import DeferredExecutionContext, SyncDataLoader
+
 from ariadne import QueryType, graphql, graphql_sync, make_executable_schema
-
-PY_37 = sys.version_info < (3, 8)
-
-if not PY_37:
-    # Sync dataloader is python 3.8 and later only
-    # pylint: disable=import-error
-    from graphql_sync_dataloaders import DeferredExecutionContext, SyncDataLoader
 
 
 @pytest.mark.asyncio
@@ -42,7 +37,6 @@ async def test_graphql_supports_async_dataloaders():
     assert result["data"] == {"test1": "1", "test2": "2"}
 
 
-@pytest.mark.skipif(PY_37, reason="requires python 3.8")
 def test_graphql_sync_supports_sync_dataloaders():
     type_defs = """
         type Query {

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from io import BytesIO
 from unittest.mock import ANY, Mock
 

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -8,6 +8,7 @@ from graphql import (
     GraphQLError,
     parse,
 )
+from graphql_sync_dataloaders import DeferredExecutionContext, SyncDataLoader
 from werkzeug.test import Client
 from werkzeug.wrappers import Response
 
@@ -15,13 +16,6 @@ from ariadne import QueryType, make_executable_schema
 from ariadne.constants import DATA_TYPE_JSON
 from ariadne.types import Extension
 from ariadne.wsgi import GraphQL
-
-PY_37 = sys.version_info < (3, 8)
-
-if not PY_37:
-    # Sync dataloader is python 3.8 and later only
-    # pylint: disable=import-error
-    from graphql_sync_dataloaders import DeferredExecutionContext, SyncDataLoader
 
 
 # Add TestClient to keep test similar to ASGI
@@ -264,7 +258,6 @@ def test_middleware_function_result_is_passed_to_query_executor(schema):
     assert result == {"data": {"hello": "**Hello, BOB!**"}}
 
 
-@pytest.mark.skipif(PY_37, reason="requires python 3.8")
 def test_wsgi_app_supports_sync_dataloader_with_custom_execution_context():
     type_defs = """
         type Query {


### PR DESCRIPTION
Python 3.7 support ends on 27th of June, in 3 weeks. Flask already abandoned support for it in latest release, I think its safe for us to do it too.