### PR TITLE
Move WebSocketConnectionError to exceptions (#1026)

### DIFF
--- a/ariadne/asgi/__init__.py
+++ b/ariadne/asgi/__init__.py
@@ -1,3 +1,4 @@
+from ..exceptions import WebSocketConnectionError
 from ..types import (
     Extensions,
     MiddlewareList,
@@ -7,7 +8,6 @@ from ..types import (
     OnDisconnect,
     OnOperation,
     Operation,
-    WebSocketConnectionError,
 )
 from .graphql import GraphQL
 

--- a/ariadne/asgi/handlers/graphql_ws.py
+++ b/ariadne/asgi/handlers/graphql_ws.py
@@ -7,11 +7,11 @@ from graphql.language import OperationType
 from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState
 
+from ...exceptions import WebSocketConnectionError
 from ...graphql import parse_query, subscribe, validate_data
 from ...logger import log_error
 from ...types import (
     Operation,
-    WebSocketConnectionError,
 )
 from ...utils import get_operation_type
 from .base import GraphQLWebsocketHandler

--- a/ariadne/exceptions.py
+++ b/ariadne/exceptions.py
@@ -62,3 +62,15 @@ class GraphQLFileSyntaxError(Exception):
     def __str__(self):
         """Returns error message."""
         return self.message
+
+
+class WebSocketConnectionError(Exception):
+    """Special error class enabling custom error reporting for on_connect"""
+
+    def __init__(self, payload: Optional[Union[dict, str]] = None) -> None:
+        if isinstance(payload, dict):
+            self.payload = payload
+        elif payload:
+            self.payload = {"message": str(payload)}
+        else:
+            self.payload = {"message": "Unexpected error has occurred."}

--- a/ariadne/types.py
+++ b/ariadne/types.py
@@ -47,7 +47,6 @@ __all__ = [
     "OnDisconnect",
     "OnOperation",
     "OnComplete",
-    "WebSocketConnectionError",
     "Extension",
     "SchemaBindable",
 ]
@@ -501,18 +500,6 @@ Called with two arguments:
 `Operation`: an object with closed subscription's data.
 """
 OnComplete = Callable[[WebSocket, Operation], Any]
-
-
-class WebSocketConnectionError(Exception):
-    """Special error class enabling custom error reporting for on_connect"""
-
-    def __init__(self, payload: Optional[Union[dict, str]] = None) -> None:
-        if isinstance(payload, dict):
-            self.payload = payload
-        elif payload:
-            self.payload = {"message": str(payload)}
-        else:
-            self.payload = {"message": "Unexpected error has occurred."}
 
 
 class Extension:

--- a/tests/asgi/test_websockets_graphql_transport_ws.py
+++ b/tests/asgi/test_websockets_graphql_transport_ws.py
@@ -9,7 +9,7 @@ from starlette.websockets import WebSocketDisconnect
 
 from ariadne.asgi import GraphQL
 from ariadne.asgi.handlers import GraphQLTransportWSHandler
-from ariadne.types import WebSocketConnectionError
+from ariadne.exceptions import WebSocketConnectionError
 from ariadne.utils import get_operation_type
 
 

--- a/tests/asgi/test_websockets_graphql_ws.py
+++ b/tests/asgi/test_websockets_graphql_ws.py
@@ -7,7 +7,7 @@ from starlette.testclient import TestClient
 
 from ariadne.asgi import GraphQL
 from ariadne.asgi.handlers import GraphQLWSHandler
-from ariadne.types import WebSocketConnectionError
+from ariadne.exceptions import WebSocketConnectionError
 
 
 def test_field_can_be_subscribed_using_websocket_connection(client):


### PR DESCRIPTION
Addressing issue #1026 

There was a request for this, and it seems clearer to have the WebSocketConnectionError with the other exceptions rather than with the types. 