### PR TITLE
Fix GraphQLTransportWSHandler returning invalid error message for `query` and `mutation` errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Deprecated `EnumType.bind_to_default_values` method. It will be removed in a future release.
 - Added `repair_schema_default_enum_values` to public API.
 - Removed `validate_schema_enum_values` and introduced `validate_schema_default_enum_values` in its place. This is a breaking change.
+- Fixed an invalid error message returned by the `GraphQLTransportWSHandler` for `query` and `mutation` operations.
 
 
 ## 0.21 (2023-11-08)

--- a/ariadne/asgi/handlers/graphql_transport_ws.py
+++ b/ariadne/asgi/handlers/graphql_transport_ws.py
@@ -2,7 +2,7 @@ import asyncio
 from contextlib import suppress
 from datetime import timedelta
 from inspect import isawaitable
-from typing import Any, AsyncGenerator, Dict, Optional, cast
+from typing import Any, AsyncGenerator, Dict, List, Optional, cast
 
 from graphql import GraphQLError
 from graphql.language import OperationType
@@ -374,13 +374,15 @@ class GraphQLTransportWSHandler(GraphQLWebsocketHandler):
 
         if not success:
             if not isinstance(results_producer, list):
-                results_producer = [results_producer]
+                error_payload = cast(List[dict], [results_producer])
+            else:
+                error_payload = results_producer
 
             await websocket.send_json(
                 {
                     "type": GraphQLTransportWSHandler.GQL_ERROR,
                     "id": operation_id,
-                    "payload": results_producer,
+                    "payload": error_payload,
                 }
             )
         else:

--- a/ariadne/asgi/handlers/graphql_transport_ws.py
+++ b/ariadne/asgi/handlers/graphql_transport_ws.py
@@ -367,15 +367,20 @@ class GraphQLTransportWSHandler(GraphQLWebsocketHandler):
                 yield result
 
             # if success then AsyncGenerator is expected, for error it will be List
-            results_producer = get_results() if success else [result]
+            if success:
+                results_producer = get_results()
+            else:
+                results_producer = result["errors"]
 
         if not success:
-            results_producer = cast(List[dict], results_producer)
+            if not isinstance(results_producer, list):
+                results_producer = [results_producer]
+
             await websocket.send_json(
                 {
                     "type": GraphQLTransportWSHandler.GQL_ERROR,
                     "id": operation_id,
-                    "payload": [results_producer[0]],
+                    "payload": results_producer,
                 }
             )
         else:

--- a/ariadne/asgi/handlers/graphql_transport_ws.py
+++ b/ariadne/asgi/handlers/graphql_transport_ws.py
@@ -2,7 +2,7 @@ import asyncio
 from contextlib import suppress
 from datetime import timedelta
 from inspect import isawaitable
-from typing import Any, AsyncGenerator, Dict, List, Optional, cast
+from typing import Any, AsyncGenerator, Dict, Optional, cast
 
 from graphql import GraphQLError
 from graphql.language import OperationType

--- a/tests/asgi/__snapshots__/test_websockets_graphql_transport_ws.ambr
+++ b/tests/asgi/__snapshots__/test_websockets_graphql_transport_ws.ambr
@@ -1,0 +1,23 @@
+# serializer version: 1
+# name: test_invalid_query_error_is_handled_using_websocket_connection_graphql_transport_ws
+  list([
+    dict({
+      'locations': list([
+        dict({
+          'column': 17,
+          'line': 1,
+        }),
+      ]),
+      'message': "Cannot query field 'error' on type 'Query'.",
+    }),
+    dict({
+      'locations': list([
+        dict({
+          'column': 23,
+          'line': 1,
+        }),
+      ]),
+      'message': "Cannot query field 'other' on type 'Query'.",
+    }),
+  ])
+# ---


### PR DESCRIPTION
Fixes #1053 