### PR TITLE
Release Ariadne 0.22 Beta 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.22 (2024-01-08)
+## 0.22 (UNRELEASED)
 
 - Deprecated `EnumType.bind_to_default_values` method. It will be removed in a future release.
 - Added `repair_schema_default_enum_values` to public API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## 0.21 (2023-11-08)
+## 0.22 (2024-01-08)
 
 - Deprecated `EnumType.bind_to_default_values` method. It will be removed in a future release.
 - Added `repair_schema_default_enum_values` to public API.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ariadne"
-version = "0.22"
+version = "0.22.0b1"
 description = "Ariadne is a Python library for implementing GraphQL servers."
 authors = [{ name = "Mirumee Software", email = "hello@mirumee.com" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ariadne"
-version = "0.21"
+version = "0.22"
 description = "Ariadne is a Python library for implementing GraphQL servers."
 authors = [{ name = "Mirumee Software", email = "hello@mirumee.com" }]
 readme = "README.md"


### PR DESCRIPTION
# CHANGELOG

- Deprecated `EnumType.bind_to_default_values` method. It will be removed in a future release.
- Added `repair_schema_default_enum_values` to public API.
- Removed `validate_schema_enum_values` and introduced `validate_schema_default_enum_values` in its place. This is a breaking change.
- Fixed an invalid error message returned by the `GraphQLTransportWSHandler` for `query` and `mutation` operations.
