### PR TITLE
Fix websockets tests for new Starlette

### DIFF
--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -684,10 +684,12 @@ def test_init_wait_timeout_graphql_transport_ws(
     app = GraphQL(schema, websocket_handler=websocket_handler)
     client = TestClient(app)
 
-    with pytest.raises(WebSocketDisconnect, match="4408"):
+    with pytest.raises(WebSocketDisconnect) as exc_info:
         with client.websocket_connect("/", ["graphql-transport-ws"]) as ws:
             time.sleep(0.1)
             ws.receive_json()
+
+    assert exc_info.value.code == 4408
 
 
 @pytest.mark.xfail(reason="sometimes fails due to a race condition")

--- a/tests/asgi/test_websockets_graphql_transport_ws.py
+++ b/tests/asgi/test_websockets_graphql_transport_ws.py
@@ -767,8 +767,11 @@ def test_too_many_connection_init_messages_graphql_transport_ws(
         response = ws.receive_json()
         assert response["type"] == GraphQLTransportWSHandler.GQL_CONNECTION_ACK
         ws.send_json({"type": GraphQLTransportWSHandler.GQL_CONNECTION_INIT})
-        with pytest.raises(WebSocketDisconnect, match="4429"):
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
             ws.receive_json()
+
+        assert exc_info.value.code == 4429
 
 
 def test_get_operation_type():
@@ -796,8 +799,11 @@ def test_connection_not_acknowledged_graphql_transport_ws(
                 "payload": {"query": "subscription { ping }"},
             }
         )
-        with pytest.raises(WebSocketDisconnect, match="4401"):
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
             ws.receive_json()
+
+        assert exc_info.value.code == 4401
 
 
 def test_duplicate_operation_id_graphql_transport_ws(
@@ -822,8 +828,11 @@ def test_duplicate_operation_id_graphql_transport_ws(
             }
         )
         ws.receive_json()
-        with pytest.raises(WebSocketDisconnect, match="4409"):
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
             ws.receive_json()
+
+        assert exc_info.value.code == 4409
 
 
 def test_invalid_operation_id_is_handled_graphql_transport_ws(


### PR DESCRIPTION
Starlette changed `WebSocketDisconnect` which prevents pytest's `pytest.raises(..., match="")` to work anymore.