### PR TITLE
Execute queries over GET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.23 (UNRELEASED)
 
-- Added `execute_get_queries` option to the `GraphQL` apps that controls execution of the GraphQL "query" type operations made with GET requests. Defaults to `False`.
+- Added `execute_get_queries` setting to the `GraphQL` apps that controls execution of the GraphQL "query" operations made with GET requests. Defaults to `False`.
 - Added support for the Apollo Federation versions up to 2.6.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.23 (UNRELEASED)
+
+- Added `execute_get_queries` option to the `GraphQL` apps that controls execution of the GraphQL "query" type operations made with GET requests. Defaults to `False`.
+- Added support for the Apollo Federation versions up to 2.6.
+
+
 ## 0.22 (2024-01-31)
 
 - Deprecated `EnumType.bind_to_default_values` method. It will be removed in a future release.

--- a/ariadne/asgi/graphql.py
+++ b/ariadne/asgi/graphql.py
@@ -39,6 +39,7 @@ class GraphQL:
         query_parser: Optional[QueryParser] = None,
         query_validator: Optional[QueryValidator] = None,
         validation_rules: Optional[ValidationRules] = None,
+        execute_get_queries: bool = False,
         debug: bool = False,
         introspection: bool = True,
         explorer: Optional[Explorer] = None,
@@ -72,6 +73,9 @@ class GraphQL:
         `validation_rules`: a `ValidationRules` list or callable returning a
         list of extra validation rules server should use to validate the
         GraphQL queries. Defaults to `None`.
+
+        `execute_get_queries`: a `bool` that controls if `query` operations
+        sent using the `GET` method should be executed. Defaults to `False`.
 
         `debug`: a `bool` controlling in server should run in debug mode or
         not. Controls details included in error data returned to clients.
@@ -126,6 +130,7 @@ class GraphQL:
             query_parser,
             query_validator,
             validation_rules,
+            execute_get_queries,
             debug,
             introspection,
             explorer,
@@ -140,6 +145,7 @@ class GraphQL:
             query_parser,
             query_validator,
             validation_rules,
+            execute_get_queries,
             debug,
             introspection,
             explorer,

--- a/ariadne/asgi/handlers/base.py
+++ b/ariadne/asgi/handlers/base.py
@@ -40,6 +40,7 @@ class GraphQLHandler(ABC):
         self.query_parser: Optional[QueryParser] = None
         self.query_validator: Optional[QueryValidator] = None
         self.validation_rules: Optional[ValidationRules] = None
+        self.execute_get_queries: bool = False
         self.execution_context_class: Optional[Type[ExecutionContext]] = None
         self.middleware_manager_class: Optional[Type[MiddlewareManager]] = None
 
@@ -79,6 +80,7 @@ class GraphQLHandler(ABC):
         query_parser: Optional[QueryParser] = None,
         query_validator: Optional[QueryValidator] = None,
         validation_rules: Optional[ValidationRules] = None,
+        execute_get_queries: bool = False,
         debug: bool = False,
         introspection: bool = True,
         explorer: Optional[Explorer] = None,
@@ -94,6 +96,7 @@ class GraphQLHandler(ABC):
         self.context_value = context_value
         self.debug = debug
         self.error_formatter = error_formatter
+        self.execute_get_queries = execute_get_queries
         self.execution_context_class = execution_context_class
         self.introspection = introspection
         self.explorer = explorer

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -35,7 +35,6 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
 
     def __init__(
         self,
-        execute_get_queries: bool = False,
         extensions: Optional[Extensions] = None,
         middleware: Optional[Middlewares] = None,
         middleware_manager_class: Optional[Type[MiddlewareManager]] = None,
@@ -43,9 +42,6 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
         """Initializes the HTTP handler.
 
         # Optional arguments
-
-        `execute_get_queries`: a `bool` that controls if `query` operations
-        sent using the `GET` method should be executed. Defaults to `False`.
 
         `extensions`: an `Extensions` list or callable returning a
         list of extensions server should use during query execution. Defaults
@@ -62,7 +58,6 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
         """
         super().__init__()
 
-        self.execute_get_queries = execute_get_queries
         self.extensions = extensions
         self.middleware = middleware
         self.middleware_manager_class = middleware_manager_class or MiddlewareManager
@@ -195,7 +190,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
             and self.execute_get_queries
             and request.query_params.get("query")
         ):
-            return await self.extract_data_from_get_request(request)
+            return self.extract_data_from_get_request(request)
 
         raise HttpBadRequestError(
             "Posted content must be of type {} or {}".format(
@@ -256,7 +251,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
 
         return combine_multipart_data(operations, files_map, request_files)
 
-    async def extract_data_from_get_request(self, request: Request) -> dict:
+    def extract_data_from_get_request(self, request: Request) -> dict:
         """Extracts GraphQL data from GET request's querystring.
 
         Returns a `dict` with GraphQL query data that was not yet validated.

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -319,6 +319,11 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
 
         if self.schema is None:
             raise TypeError("schema is not set, call configure method to initialize it")
+        
+        if isinstance(request, Request):
+            require_query = request.method == "GET"
+        else:
+            require_query = False
 
         return await graphql(
             self.schema,
@@ -329,7 +334,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
             query_validator=self.query_validator,
             query_document=query_document,
             validation_rules=self.validation_rules,
-            require_query=request.method == "GET",
+            require_query=require_query,
             debug=self.debug,
             introspection=self.introspection,
             logger=self.logger,

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -1,6 +1,6 @@
 import json
 from inspect import isawaitable
-from typing import Any, Optional, Type, cast
+from typing import Any, Optional, Type, Union, cast
 
 from graphql import DocumentNode, MiddlewareManager
 from starlette.datastructures import UploadFile

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -122,7 +122,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
         if request.method == "GET":
             if self.execute_get_queries and request.query_params.get("query"):
                 return await self.graphql_http_server(request)
-            elif self.introspection and self.explorer:
+            if self.introspection and self.explorer:
                 # only render explorer when introspection is enabled
                 return await self.render_explorer(request, self.explorer)
 
@@ -319,7 +319,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
 
         if self.schema is None:
             raise TypeError("schema is not set, call configure method to initialize it")
-        
+
         if isinstance(request, Request):
             require_query = request.method == "GET"
         else:

--- a/ariadne/asgi/handlers/http.py
+++ b/ariadne/asgi/handlers/http.py
@@ -219,7 +219,7 @@ class GraphQLHTTPHandler(GraphQLHttpHandlerBase):
 
     async def extract_data_from_multipart_request(
         self, request: Request
-    ) -> dict | list:
+    ) -> Union[dict, list]:
         """Extracts GraphQL data from `multipart/form-data` request.
 
         Returns an unvalidated `dict` with GraphQL query data.

--- a/ariadne/graphql.py
+++ b/ariadne/graphql.py
@@ -663,12 +663,12 @@ def validate_operation_is_query(document_ast: DocumentNode, operation_name: str)
                 query_operations.append(None)
 
     if operation_name:
-        if query_operations not in query_operations:
+        if operation_name not in query_operations:
             raise GraphQLError(
                 f"Operation '{operation_name}' can't be executed using the GET "
                 "HTTP method. Use POST instead."
             )
     elif len(query_operations) != 1:
         raise GraphQLError(
-            f"'operationName' is required if 'query' defines multiple operations."
+            "'operationName' is required if 'query' defines multiple operations."
         )

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -656,7 +656,7 @@ def parse_query_string(environ: dict) -> Optional[dict]:
         return None
 
     try:
-        return {k: v for k, v in parse_qsl(query_string)}
+        return dict(parse_qsl(query_string))
     except (TypeError, ValueError):
         return None
 

--- a/ariadne/wsgi.py
+++ b/ariadne/wsgi.py
@@ -1,6 +1,7 @@
 import json
 from inspect import isawaitable
 from typing import Any, Callable, Dict, List, Optional, Type, Union, cast
+from urllib.parse import parse_qsl
 
 from graphql import (
     ExecutionContext,
@@ -75,6 +76,7 @@ class GraphQL:
         explorer: Optional[Explorer] = None,
         logger: Optional[str] = None,
         error_formatter: ErrorFormatter = format_error,
+        execute_get_queries: bool = False,
         extensions: Optional[Extensions] = None,
         middleware: Optional[Middlewares] = None,
         middleware_manager_class: Optional[Type[MiddlewareManager]] = None,
@@ -125,6 +127,9 @@ class GraphQL:
         GraphQL errors returned to clients. If not set, default formatter
         implemented by Ariadne is used.
 
+        `execute_get_queries`: a `bool` that controls if `query` operations
+        sent using the `GET` method should be executed. Defaults to `False`.
+
         `extensions`: an `Extensions` list or callable returning a
         list of extensions server should use during query execution. Defaults
         to no extensions.
@@ -152,6 +157,7 @@ class GraphQL:
         self.introspection = introspection
         self.logger = logger
         self.error_formatter = error_formatter
+        self.execute_get_queries = execute_get_queries
         self.extensions = extensions
         self.middleware = middleware
         self.middleware_manager_class = middleware_manager_class or MiddlewareManager
@@ -234,7 +240,7 @@ class GraphQL:
 
         `start_response`: a callable used to begin new HTTP response.
         """
-        if environ["REQUEST_METHOD"] == "GET" and self.introspection:
+        if environ["REQUEST_METHOD"] == "GET":
             return self.handle_get(environ, start_response)
         if environ["REQUEST_METHOD"] == "POST":
             return self.handle_post(environ, start_response)
@@ -242,7 +248,62 @@ class GraphQL:
         return self.handle_not_allowed_method(environ, start_response)
 
     def handle_get(self, environ: dict, start_response) -> List[bytes]:
-        """Handles WSGI HTTP GET request and returns a a response to the client.
+        """Handles WSGI HTTP GET request and returns a response to the client.
+
+        Returns list of bytes with response body.
+
+        # Required arguments
+
+        `environ`: a WSGI environment dictionary.
+
+        `start_response`: a callable used to begin new HTTP response.
+        """
+        query_params = parse_query_string(environ)
+        if self.execute_get_queries and query_params and query_params.get("query"):
+            return self.handle_get_query(environ, start_response, query_params)
+        if self.introspection:
+            return self.handle_get_explorer(environ, start_response)
+
+        return self.handle_not_allowed_method(environ, start_response)
+
+    def handle_get_query(
+        self, environ: dict, start_response, query_params: dict
+    ) -> List[bytes]:
+        data = self.extract_data_from_get(query_params)
+        result = self.execute_query(environ, data)
+        return self.return_response_from_result(start_response, result)
+
+    def extract_data_from_get(self, query_params: dict) -> dict:
+        """Extracts GraphQL data from GET request's querystring.
+
+        Returns a `dict` with GraphQL query data that was not yet validated.
+
+        # Required arguments
+
+        `query_params`: a `dict` with parsed query string.
+        """
+        query = query_params["query"].strip()
+        operation_name = query_params.get("operationName", "").strip()
+        variables = query_params.get("variables", "").strip()
+
+        clean_variables = None
+
+        if variables:
+            try:
+                clean_variables = json.loads(variables)
+            except (TypeError, ValueError, json.JSONDecodeError) as ex:
+                raise HttpBadRequestError(
+                    "Variables query arg is not a valid JSON"
+                ) from ex
+
+        return {
+            "query": query,
+            "operationName": operation_name or None,
+            "variables": clean_variables,
+        }
+
+    def handle_get_explorer(self, environ: dict, start_response) -> List[bytes]:
+        """Handles WSGI HTTP GET explorer request and returns a response to the client.
 
         Returns list of bytes with response body.
 
@@ -413,6 +474,7 @@ class GraphQL:
             query_parser=self.query_parser,
             query_validator=self.query_validator,
             validation_rules=self.validation_rules,
+            require_query=environ["REQUEST_METHOD"] == "GET",
             debug=self.debug,
             introspection=self.introspection,
             logger=self.logger,
@@ -586,6 +648,17 @@ class GraphQLMiddleware:
         if not environ["PATH_INFO"].startswith(self.path):
             return self.app(environ, start_response)
         return self.graphql_app(environ, start_response)
+
+
+def parse_query_string(environ: dict) -> Optional[dict]:
+    query_string = environ.get("QUERY_STRING")
+    if not query_string:
+        return None
+
+    try:
+        return {k: v for k, v in parse_qsl(query_string)}
+    except (TypeError, ValueError):
+        return None
 
 
 def parse_multipart_request(environ: dict) -> "FormData":

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -282,6 +282,34 @@ def test_query_over_get_fails_if_operation_name_is_invalid(schema):
     }
 
 
+def test_query_over_get_fails_if_operation_is_mutation(schema):
+    send_response = Mock()
+    app = GraphQL(schema, execute_get_queries=True)
+    response = app(
+        {
+            "REQUEST_METHOD": "GET",
+            "QUERY_STRING": (
+                "query=mutation Echo($text:String!) {echo(text: $text)}"
+                "&operationName=Echo"
+                '&variables={"text": "John"}'
+            ),
+        },
+        send_response,
+    )
+    send_response.assert_called_once_with(
+        "400 Bad Request", [("Content-Type", "application/json; charset=UTF-8")]
+    )
+    assert json.loads(response[0]) == {
+        "errors": [
+            {
+                "message": (
+                    "Operation 'Echo' is not defined or is not of a 'query' type."
+                )
+            }
+        ]
+    }
+
+
 def test_query_over_get_fails_if_variables_are_not_json_serialized(schema):
     send_response = Mock()
     app = GraphQL(schema, execute_get_queries=True)

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -207,7 +207,7 @@ def test_query_over_get_is_executed_if_enabled(schema):
             "REQUEST_METHOD": "GET",
             "QUERY_STRING": "query={status}",
         },
-        send_response
+        send_response,
     )
     send_response.assert_called_once_with(
         "200 OK", [("Content-Type", "application/json; charset=UTF-8")]
@@ -224,10 +224,10 @@ def test_query_over_get_is_executed_with_variables(schema):
             "QUERY_STRING": (
                 "query=query Hello($name:String) {hello(name: $name)}"
                 "&operationName=Hello"
-                "&variables={\"name\": \"John\"}"
+                '&variables={"name": "John"}'
             ),
         },
-        send_response
+        send_response,
     )
     send_response.assert_called_once_with(
         "200 OK", [("Content-Type", "application/json; charset=UTF-8")]
@@ -243,10 +243,10 @@ def test_query_over_get_is_executed_without_operation_name(schema):
             "REQUEST_METHOD": "GET",
             "QUERY_STRING": (
                 "query=query Hello($name:String) {hello(name: $name)}"
-                "&variables={\"name\": \"John\"}"
+                '&variables={"name": "John"}'
             ),
         },
-        send_response
+        send_response,
     )
     send_response.assert_called_once_with(
         "200 OK", [("Content-Type", "application/json; charset=UTF-8")]
@@ -263,10 +263,10 @@ def test_query_over_get_fails_if_operation_name_is_invalid(schema):
             "QUERY_STRING": (
                 "query=query Hello($name:String) {hello(name: $name)}"
                 "&operationName=Invalid"
-                "&variables={\"name\": \"John\"}"
+                '&variables={"name": "John"}'
             ),
         },
-        send_response
+        send_response,
     )
     send_response.assert_called_once_with(
         "400 Bad Request", [("Content-Type", "application/json; charset=UTF-8")]
@@ -291,10 +291,10 @@ def test_query_over_get_fails_if_variables_are_not_json_serialized(schema):
             "QUERY_STRING": (
                 "query=query Hello($name:String) {hello(name: $name)}"
                 "&operationName=Hello"
-                "&variables={\"name\" \"John\"}"
+                '&variables={"name" "John"}'
             ),
         },
-        send_response
+        send_response,
     )
     send_response.assert_called_once_with(
         "400 Bad Request", [("Content-Type", "text/plain; charset=UTF-8")]
@@ -310,7 +310,7 @@ def test_query_over_get_is_not_executed_if_not_enabled(schema):
             "REQUEST_METHOD": "GET",
             "QUERY_STRING": "query={status}",
         },
-        send_response
+        send_response,
     )
     send_response.assert_called_once_with(
         "200 OK", [("Content-Type", "text/html; charset=UTF-8")]

--- a/tests/wsgi/test_configuration.py
+++ b/tests/wsgi/test_configuration.py
@@ -27,21 +27,27 @@ class TestClient(Client):
 
 def test_custom_context_value_is_passed_to_resolvers(schema):
     app = GraphQL(schema, context_value={"test": "TEST-CONTEXT"})
-    _, result = app.execute_query({}, {"query": "{ testContext }"})
+    _, result = app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ testContext }"},
+    )
     assert result == {"data": {"testContext": "TEST-CONTEXT"}}
 
 
 def test_custom_context_value_function_is_set_and_called_by_app(schema):
     get_context_value = Mock(return_value=True)
     app = GraphQL(schema, context_value=get_context_value)
-    app.execute_query({}, {"query": "{ status }"})
+    app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ status }"},
+    )
     get_context_value.assert_called_once()
 
 
 def test_custom_context_value_function_is_called_with_request_value(schema):
     get_context_value = Mock(return_value=True)
     app = GraphQL(schema, context_value=get_context_value)
-    request = {"CONTENT_TYPE": DATA_TYPE_JSON}
+    request = {"CONTENT_TYPE": DATA_TYPE_JSON, "REQUEST_METHOD": "POST"}
     app.execute_query(request, {"query": "{ status }"})
     get_context_value.assert_called_once_with(request, {"query": "{ status }"})
 
@@ -49,7 +55,10 @@ def test_custom_context_value_function_is_called_with_request_value(schema):
 def test_custom_context_value_function_result_is_passed_to_resolvers(schema):
     get_context_value = Mock(return_value={"test": "TEST-CONTEXT"})
     app = GraphQL(schema, context_value=get_context_value)
-    _, result = app.execute_query({}, {"query": "{ testContext }"})
+    _, result = app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ testContext }"},
+    )
     assert result == {"data": {"testContext": "TEST-CONTEXT"}}
 
 
@@ -62,19 +71,28 @@ def test_warning_is_raised_if_custom_context_value_function_has_deprecated_signa
     app = GraphQL(schema, context_value=get_context_value)
 
     with pytest.deprecated_call():
-        app.execute_query({}, {"query": "{ status }"})
+        app.execute_query(
+            {"REQUEST_METHOD": "POST"},
+            {"query": "{ status }"},
+        )
 
 
 def test_custom_root_value_is_passed_to_resolvers(schema):
     app = GraphQL(schema, root_value={"test": "TEST-ROOT"})
-    _, result = app.execute_query({}, {"query": "{ testRoot }"})
+    _, result = app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ testRoot }"},
+    )
     assert result == {"data": {"testRoot": "TEST-ROOT"}}
 
 
 def test_custom_root_value_function_is_set_and_called_by_app(schema):
     get_root_value = Mock(return_value=True)
     app = GraphQL(schema, root_value=get_root_value)
-    app.execute_query({}, {"query": "{ status }"})
+    app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ status }"},
+    )
     get_root_value.assert_called_once()
 
 
@@ -83,7 +101,10 @@ def test_custom_root_value_function_is_called_with_context_value(schema):
     app = GraphQL(
         schema, context_value={"test": "TEST-CONTEXT"}, root_value=get_root_value
     )
-    app.execute_query({}, {"query": "{ status }"})
+    app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ status }"},
+    )
     get_root_value.assert_called_once_with({"test": "TEST-CONTEXT"}, None, None, ANY)
 
 
@@ -98,13 +119,19 @@ def test_warning_is_raised_if_custom_root_value_function_has_deprecated_signatur
     )
 
     with pytest.deprecated_call():
-        app.execute_query({}, {"query": "{ status }"})
+        app.execute_query(
+            {"REQUEST_METHOD": "POST"},
+            {"query": "{ status }"},
+        )
 
 
 def test_custom_query_parser_is_used(schema):
     mock_parser = Mock(return_value=parse("{ status }"))
     app = GraphQL(schema, query_parser=mock_parser)
-    _, result = app.execute_query({}, {"query": "{ testContext }"})
+    _, result = app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ testContext }"},
+    )
     assert result == {"data": {"status": True}}
     mock_parser.assert_called_once()
 
@@ -119,7 +146,10 @@ def test_custom_query_parser_is_used(schema):
 def test_custom_query_validator_is_used(schema, errors):
     mock_validator = Mock(return_value=errors)
     app = GraphQL(schema, query_validator=mock_validator)
-    _, result = app.execute_query({}, {"query": "{ testContext }"})
+    _, result = app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ testContext }"},
+    )
     if errors:
         assert result == {"errors": [{"message": "Nope"}]}
     else:
@@ -132,7 +162,10 @@ def test_custom_validation_rule_is_called_by_query_validation(
 ):
     spy_validation_rule = mocker.spy(validation_rule, "__init__")
     app = GraphQL(schema, validation_rules=[validation_rule])
-    app.execute_query({}, {"query": "{ status }"})
+    app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ status }"},
+    )
     spy_validation_rule.assert_called_once()
 
 
@@ -142,7 +175,10 @@ def test_custom_validation_rules_function_is_set_and_called_on_query_execution(
     spy_validation_rule = mocker.spy(validation_rule, "__init__")
     get_validation_rules = Mock(return_value=[validation_rule])
     app = GraphQL(schema, validation_rules=get_validation_rules)
-    app.execute_query({}, {"query": "{ status }"})
+    app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ status }"},
+    )
     get_validation_rules.assert_called_once()
     spy_validation_rule.assert_called_once()
 
@@ -156,8 +192,129 @@ def test_custom_validation_rules_function_is_called_with_context_value(
         context_value={"test": "TEST-CONTEXT"},
         validation_rules=get_validation_rules,
     )
-    app.execute_query({}, {"query": "{ status }"})
+    app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": "{ status }"},
+    )
     get_validation_rules.assert_called_once_with({"test": "TEST-CONTEXT"}, ANY, ANY)
+
+
+def test_query_over_get_is_executed_if_enabled(schema):
+    send_response = Mock()
+    app = GraphQL(schema, execute_get_queries=True)
+    response = app(
+        {
+            "REQUEST_METHOD": "GET",
+            "QUERY_STRING": "query={status}",
+        },
+        send_response
+    )
+    send_response.assert_called_once_with(
+        "200 OK", [("Content-Type", "application/json; charset=UTF-8")]
+    )
+    assert json.loads(response[0]) == {"data": {"status": True}}
+
+
+def test_query_over_get_is_executed_with_variables(schema):
+    send_response = Mock()
+    app = GraphQL(schema, execute_get_queries=True)
+    response = app(
+        {
+            "REQUEST_METHOD": "GET",
+            "QUERY_STRING": (
+                "query=query Hello($name:String) {hello(name: $name)}"
+                "&operationName=Hello"
+                "&variables={\"name\": \"John\"}"
+            ),
+        },
+        send_response
+    )
+    send_response.assert_called_once_with(
+        "200 OK", [("Content-Type", "application/json; charset=UTF-8")]
+    )
+    assert json.loads(response[0]) == {"data": {"hello": "Hello, John!"}}
+
+
+def test_query_over_get_is_executed_without_operation_name(schema):
+    send_response = Mock()
+    app = GraphQL(schema, execute_get_queries=True)
+    response = app(
+        {
+            "REQUEST_METHOD": "GET",
+            "QUERY_STRING": (
+                "query=query Hello($name:String) {hello(name: $name)}"
+                "&variables={\"name\": \"John\"}"
+            ),
+        },
+        send_response
+    )
+    send_response.assert_called_once_with(
+        "200 OK", [("Content-Type", "application/json; charset=UTF-8")]
+    )
+    assert json.loads(response[0]) == {"data": {"hello": "Hello, John!"}}
+
+
+def test_query_over_get_fails_if_operation_name_is_invalid(schema):
+    send_response = Mock()
+    app = GraphQL(schema, execute_get_queries=True)
+    response = app(
+        {
+            "REQUEST_METHOD": "GET",
+            "QUERY_STRING": (
+                "query=query Hello($name:String) {hello(name: $name)}"
+                "&operationName=Invalid"
+                "&variables={\"name\": \"John\"}"
+            ),
+        },
+        send_response
+    )
+    send_response.assert_called_once_with(
+        "400 Bad Request", [("Content-Type", "application/json; charset=UTF-8")]
+    )
+    assert json.loads(response[0]) == {
+        "errors": [
+            {
+                "message": (
+                    "Operation 'Invalid' is not defined or is not of a 'query' type."
+                )
+            }
+        ]
+    }
+
+
+def test_query_over_get_fails_if_variables_are_not_json_serialized(schema):
+    send_response = Mock()
+    app = GraphQL(schema, execute_get_queries=True)
+    response = app(
+        {
+            "REQUEST_METHOD": "GET",
+            "QUERY_STRING": (
+                "query=query Hello($name:String) {hello(name: $name)}"
+                "&operationName=Hello"
+                "&variables={\"name\" \"John\"}"
+            ),
+        },
+        send_response
+    )
+    send_response.assert_called_once_with(
+        "400 Bad Request", [("Content-Type", "text/plain; charset=UTF-8")]
+    )
+    assert response[0] == b"Variables query arg is not a valid JSON"
+
+
+def test_query_over_get_is_not_executed_if_not_enabled(schema):
+    send_response = Mock()
+    app = GraphQL(schema, execute_get_queries=False)
+    app.handle_request(
+        {
+            "REQUEST_METHOD": "GET",
+            "QUERY_STRING": "query={status}",
+        },
+        send_response
+    )
+    send_response.assert_called_once_with(
+        "200 OK", [("Content-Type", "text/html; charset=UTF-8")]
+    )
 
 
 def execute_failing_query(app):
@@ -244,7 +401,10 @@ def middleware(next_fn, *args, **kwargs):
 
 def test_middlewares_are_passed_to_query_executor(schema):
     app = GraphQL(schema, middleware=[middleware])
-    _, result = app.execute_query({}, {"query": '{ hello(name: "BOB") }'})
+    _, result = app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": '{ hello(name: "BOB") }'},
+    )
     assert result == {"data": {"hello": "**Hello, BOB!**"}}
 
 
@@ -253,7 +413,10 @@ def test_middleware_function_result_is_passed_to_query_executor(schema):
         return [middleware]
 
     app = GraphQL(schema, middleware=get_middleware)
-    _, result = app.execute_query({}, {"query": '{ hello(name: "BOB") }'})
+    _, result = app.execute_query(
+        {"REQUEST_METHOD": "POST"},
+        {"query": '{ hello(name: "BOB") }'},
+    )
     assert result == {"data": {"hello": "**Hello, BOB!**"}}
 
 


### PR DESCRIPTION
Adds support for executing GraphQL queries sent over GET, as per [spec](https://graphql.org/learn/serving-over-http/#get-request).

Fixes #123

# TODO

- [x] ASGI
- [x] WSGI
- [x] Tests
- [x] Changelog