### PR TITLE
Fixes #1188 purge directives marked as repeatable

### DIFF
--- a/ariadne/contrib/federation/utils.py
+++ b/ariadne/contrib/federation/utils.py
@@ -29,7 +29,7 @@ _r_directive_definition = re.compile(
     f"{_i_token_delimiter}directive"
     f"(?:{_i_token_delimiter})?@({_i_token_name})"
     f"(?:(?:{_i_token_delimiter})?{_i_token_arguments})?"
-    f"{_i_token_delimiter}on"
+    f"{_i_token_delimiter}(?:repeatable)?(?:{_i_token_delimiter})?on"
     f"{_i_token_delimiter}(?:[|]{_i_token_delimiter})?{_i_token_location}"
     f"(?:{_i_token_delimiter}[|]{_i_token_delimiter}{_i_token_location})*"
     ")"

--- a/tests/federation/test_utils.py
+++ b/tests/federation/test_utils.py
@@ -63,6 +63,8 @@ def test_purge_directives_remove_custom_directives():
 
         directive @another on FIELD
 
+        directive @plural repeatable on FIELD
+
         type Query {
             field1: String @custom
             field2: String @other


### PR DESCRIPTION
This PR updates the regex used for purging directives from the sdl to include directives containing the `repeatable` tag.