### PR TITLE
fix(relay): add missing key in return RelayObjectType.resolve_wrapper

### DIFF
--- a/ariadne/contrib/relay/connection.py
+++ b/ariadne/contrib/relay/connection.py
@@ -27,8 +27,8 @@ class RelayConnection:
         return {
             "hasNextPage": self.has_next_page,
             "hasPreviousPage": self.has_previous_page,
-            "startCursor": self.get_cursor(self.edges[0]),
-            "endCursor": self.get_cursor(self.edges[-1]),
+            "startCursor": self.get_cursor(self.edges[0]) if self.edges else None,
+            "endCursor": self.get_cursor(self.edges[-1]) if self.edges else None,
         }
 
     def get_edges(self):

--- a/ariadne/contrib/relay/objects.py
+++ b/ariadne/contrib/relay/objects.py
@@ -45,6 +45,7 @@ class RelayObjectType(ObjectType):
                     if is_awaitable(relay_connection):
                         relay_connection = await relay_connection
                     return {
+                        "totalCount": relay_connection.total,
                         "edges": relay_connection.get_edges(),
                         "pageInfo": relay_connection.get_page_info(
                             connection_arguments
@@ -57,6 +58,7 @@ class RelayObjectType(ObjectType):
                 obj, info, connection_arguments, *args, **kwargs
             )
             return {
+                "totalCount": relay_connection.total,
                 "edges": relay_connection.get_edges(),
                 "pageInfo": relay_connection.get_page_info(connection_arguments),
             }


### PR DESCRIPTION
The pull request fix missing `totalCount` key in relay connection response.

Additionally handle a scenario when empty list of edges is passed to `RelayConnection`