### PR TITLE
fix: websocket connection init timeout set to 0

### DIFF
--- a/ariadne/asgi/handlers/graphql_transport_ws.py
+++ b/ariadne/asgi/handlers/graphql_transport_ws.py
@@ -105,13 +105,14 @@ class GraphQLTransportWSHandler(GraphQLWebsocketHandler):
 
         `websocket`: the `WebSocket` instance from Starlette or FastAPI.
         """
+        await websocket.accept("graphql-transport-ws")
+
         client_context = ClientContext()
         timeout_handler = self.handle_connection_init_timeout(websocket, client_context)
         client_context.connection_init_timeout_task = asyncio.create_task(
             timeout_handler
         )
 
-        await websocket.accept("graphql-transport-ws")
         try:
             while WebSocketState.DISCONNECTED not in (
                 websocket.client_state,

--- a/tests/asgi/test_configuration.py
+++ b/tests/asgi/test_configuration.py
@@ -761,11 +761,6 @@ def test_async_middleware_function_result_is_passed_to_query_executor(schema):
     assert response.json() == {"data": {"hello": "**Hello, BOB!**"}}
 
 
-@pytest.mark.skip(
-    "This test fails with Starlette version 0.45.1,"
-    "but it seems it's the issue with the code itself."
-    "See https://github.com/mirumee/ariadne/issues/1217."
-)
 def test_init_wait_timeout_graphql_transport_ws(
     schema,
 ):


### PR DESCRIPTION
In case of `connection_init_wait_timeout` set to 0, ws connection was closed before it was even accepted, so accepting connection was throwing an error. Moving `websocket.accept()` to the top fixes the issue. 

Fixes https://github.com/mirumee/ariadne/issues/1217