### PR TITLE
docs(README.md): Add versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ uvicorn example:app
 
 For more guides and examples, please see the [documentation](https://ariadnegraphql.org).
 
+## Versioning policy ##
+`ariadne` follows a custom versioning scheme where the minor version increases for breaking changes, while the patch version increments for bug fixes, enhancements, and other non-breaking updates.
+
+Since `ariadne` has not yet reached a stable API, this approach is in place until version 1.0.0. Once the API stabilizes, the project will adopt [Semantic Versioning](https://semver.org/).
+
 
 ## Contributing
 


### PR DESCRIPTION
Since the `ariadne` project has not yet reached a stable API, we are adapting our versioning policy to accommodate ongoing changes.

## Versioning policy ##
`ariadne` follows a custom versioning scheme where the minor version increases for breaking changes, while the patch version increments for bug fixes, enhancements, and other non-breaking updates.

Since `ariadne` has not yet reached a stable API, this approach is in place until version 1.0.0. Once the API stabilizes, the project will adopt [Semantic Versioning](https://semver.org/).