### PR TITLE
deps: bump graphql-core version to 3.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-  "graphql-core>=3.2.0,<3.2.6",
+  "graphql-core>=3.2.0,<=3.2.7",
   "starlette>0.17,<1.0",
   "typing_extensions>=3.6.0",
 ]


### PR DESCRIPTION
This should allow the usage of `@oneOf` directive (Related issues: #1193 and #1194) which was added in the [3.2.7](https://github.com/graphql-python/graphql-core/releases/tag/v3.2.7) release