### PR TITLE
fix: don't reject queries using variables when cost_validator has none (#1319)

### DIFF
--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -94,8 +94,21 @@ class CostValidator(ValidationRule):
                         field, child_node, self.variables
                     )
                 except Exception as e:
-                    report_error(self.context, e)
-                    field_args = {}
+                    # When the validator is configured without per-request
+                    # variables (the common case for a static `validation_rules`
+                    # list), `get_argument_values` raises for any argument
+                    # whose value comes from a query variable. That is not a
+                    # user-facing validation error — it is a cost-computation
+                    # limitation. Fall back to an empty args dict so the query
+                    # is allowed to run; the cost contribution from variable
+                    # multipliers is simply not counted. When variables are
+                    # supplied, real argument-resolution errors are still
+                    # reported as before. See issue #1319.
+                    if self.variables is None:
+                        field_args = {}
+                    else:
+                        report_error(self.context, e)
+                        field_args = {}
                 if self.cost_map:
                     cost_map_args = (
                         self.get_args_from_cost_map(

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -651,3 +651,93 @@ def test_child_fragment_cost_defined_in_directive_is_multiplied_by_values_from_l
             extensions={"cost": {"requestedQueryCost": 20, "maximumAvailable": 3}},
         )
     ]
+
+
+def test_query_with_required_variable_is_not_rejected_when_variables_not_passed(
+    schema,
+):
+    """Regression for #1319.
+
+    When `cost_validator` is configured without per-request variables (the
+    common case for a static `validation_rules=[cost_validator(...)]`), any
+    query whose arguments are supplied via GraphQL variables must still be
+    allowed through. Cost computation degrades gracefully — variable-driven
+    multipliers are simply not counted — but the query is not rejected with
+    a spurious validation error.
+    """
+    query = """
+        query testQuery($value: Int!) {
+            simple(value: $value)
+        }
+    """
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=100, cost_map=cost_map)
+    # Before the fix, this returned a GraphQLError complaining that the
+    # variable was "not provided a runtime value", aborting every query.
+    assert validate(schema, ast, [rule]) == []
+
+
+def test_query_with_required_input_variable_is_not_rejected_when_variables_not_passed(
+    schema,
+):
+    """Regression for #1319 — same fix exercised on a non-null input type."""
+    type_defs = """
+        type Query { _dummy: String }
+        type Mutation { echo(input: EchoInput!): String }
+        input EchoInput { message: String! }
+    """
+    mutation_schema = make_executable_schema(type_defs)
+    query = "mutation Echo($input: EchoInput!) { echo(input: $input) }"
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=100, default_complexity=1)
+    assert validate(mutation_schema, ast, [rule]) == []
+
+
+def test_cost_computation_skips_variable_multipliers_when_variables_not_passed(
+    schema,
+):
+    """Regression for #1319.
+
+    Cost computation is best-effort when no variables are supplied: the
+    multiplier from a variable-driven argument is simply not counted, so the
+    static-rule form still produces a finite cost rather than an error.
+    """
+    query = """
+        query testQuery($value: Int!) {
+            simple(value: $value)
+        }
+    """
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=0, default_cost=0, cost_map=cost_map)
+    # With the fix, no variable value is available so `simple` collapses to
+    # its base complexity (1) with no multiplier. maximum_cost=0 forces the
+    # only error path to be the cost-exceeded check, which proves the rule
+    # is still computing — not crashing on the variable lookup.
+    result = validate(schema, ast, [rule])
+    assert result == [
+        GraphQLError(
+            "The query exceeds the maximum cost of 0. Actual cost is 1",
+            extensions={"cost": {"requestedQueryCost": 1, "maximumAvailable": 0}},
+        )
+    ]
+
+
+def test_explicit_variables_dict_still_reports_missing_variable_errors(schema):
+    """Regression for #1319 — explicit `variables={}` keeps current behaviour.
+
+    When the caller passes a `variables` dict, they have told the validator
+    what is available; a query that references a variable not in the dict
+    is still surfaced as a validation error (no silent fallback). This
+    guards against the fix loosening validation in a case the caller can
+    actually catch.
+    """
+    query = """
+        query testQuery($value: Int!) {
+            simple(value: $value)
+        }
+    """
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=100, variables={}, cost_map=cost_map)
+    result = validate(schema, ast, [rule])
+    assert len(result) == 1
+    assert "was not provided a runtime value" in str(result[0])


### PR DESCRIPTION
## Summary

`cost_validator()` returns a validation rule that takes an optional `variables` dict, baked into the class at construction time. When the rule is added to a **static** `validation_rules=[cost_validator(...)]` list — the natural form most users reach for — it never receives per-request variables. `get_argument_values` then raises a `GraphQLError` for any argument supplied via a query variable, and every such query is rejected with a misleading *"was not provided a runtime value"* message.

This PR makes that failure mode non-fatal: when `self.variables is None`, the validator falls back to an empty args dict instead of reporting an error, so the query is allowed to run. Variable-driven multipliers are simply not counted in the cost. When the caller does pass an explicit `variables` dict, behaviour is unchanged — missing entries are still reported as validation errors (the caller has told the validator what is available).

Fixes #1319.

## Context

Root cause is in `ariadne/validation/query_cost.py`, lines 92-98. The `try/except` around `get_argument_values` reported any exception via `report_error`, which surfaces as a client-facing validation error and aborts the query. The function's signature (`get_argument_values(field, child_node, variable_values=None)`) raises on the first non-null variable it can't resolve, so for the static-rule form this triggers on every query that uses a non-null variable.

The documented workaround — passing `validation_rules` as a per-request callable — keeps working unchanged; this fix only removes the spurious failure on the static form.

## Changes

- `ariadne/validation/query_cost.py` — in `CostValidator.compute_node_cost`, branch on `self.variables is None`: silently fall back to empty `field_args` (cost is best-effort), otherwise preserve the existing `report_error` path. Added a `# See issue #1319.` comment so a reviewer reading the diff cold understands the invariant.
- `tests/test_query_cost_validation.py` — four new regression tests covering: required scalar variable, required non-null input variable, best-effort cost computation with a missing variable, and explicit `variables={}` still surfacing errors (guards against the fix loosening behaviour where the caller can actually catch it).

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/mirumee/ariadne.git /tmp/repro-1319 && cd /tmp/repro-1319
python -m venv .venv && source .venv/bin/activate
pip install -e . pytest >/dev/null

cat > /tmp/repro_1319.py <<'PY'
from graphql.language import parse
from graphql.validation import validate
from ariadne import make_executable_schema
from ariadne.validation import cost_validator

type_defs = """
    type Query { _dummy: String }
    type Mutation { echo(input: EchoInput!): String }
    input EchoInput { message: String! }
"""
schema = make_executable_schema(type_defs)
query = "mutation Echo($input: EchoInput!) { echo(input: $input) }"
rule = cost_validator(maximum_cost=100, default_complexity=1)
errors = validate(schema, parse(query), [rule])
print("errors:", errors)
PY

# --- BEFORE: origin/main, expect the spurious validation error ---
git checkout origin/main -- ariadne/ 2>/dev/null
python /tmp/repro_1319.py
# Expected: errors: [GraphQLError("Argument 'input' of required type 'EchoInput!' was provided the variable '$input' which was not provided a runtime value...")]

# --- AFTER: this branch, expect no errors ---
git fetch https://github.com/jbbqqf/ariadne.git fix/1319-cost-validator-variables
git checkout FETCH_HEAD -- ariadne/
python /tmp/repro_1319.py
# Expected: errors: []
```

## What I ran locally

```
$ pytest tests/test_query_cost_validation.py -v
...
tests/test_query_cost_validation.py::test_query_with_required_variable_is_not_rejected_when_variables_not_passed PASSED
tests/test_query_cost_validation.py::test_query_with_required_input_variable_is_not_rejected_when_variables_not_passed PASSED
tests/test_query_cost_validation.py::test_cost_computation_skips_variable_multipliers_when_variables_not_passed PASSED
tests/test_query_cost_validation.py::test_explicit_variables_dict_still_reports_missing_variable_errors PASSED
============================== 36 passed in 0.10s ==============================

$ pytest -q
....................................................................... [100%]
737 passed, 1 skipped in 82.72s
```

I also confirmed the three new "non-rejection" tests fail on `origin/main` by stashing only `ariadne/validation/query_cost.py` (keeping the new tests):

```
FAILED tests/test_query_cost_validation.py::test_query_with_required_variable_is_not_rejected_when_variables_not_passed
FAILED tests/test_query_cost_validation.py::test_query_with_required_input_variable_is_not_rejected_when_variables_not_passed
FAILED tests/test_query_cost_validation.py::test_cost_computation_skips_variable_multipliers_when_variables_not_passed
```

## Edge cases

| # | Scenario | `variables=` | Query | Before | After |
|---|---|---|---|---|---|
| 1 | Static rule, query uses variable | `None` (default) | `query($v: Int!){ simple(value: $v) }` | rejected with "not provided a runtime value" | allowed; cost = `default_complexity` |
| 2 | Static rule, non-null input variable | `None` | `mutation($i: I!){ echo(input: $i) }` | rejected | allowed |
| 3 | Static rule, no variables in query | `None` | `{ constant }` | allowed | allowed (unchanged) |
| 4 | Explicit dict, variable present | `{"v": 5}` | `query($v: Int!){ simple(value: $v) }` | allowed, multiplier counted | allowed, multiplier counted (unchanged) |
| 5 | Explicit dict, variable missing | `{}` | `query($v: Int!){ simple(value: $v) }` | rejected | rejected (preserved on purpose — caller said what's available) |
| 6 | Cost-map / directive misconfig | any | n/a | reports `TypeError`/`ValueError` from `compute_cost` | reports `TypeError`/`ValueError` (unchanged — different `except` branch) |

## Risk / blast radius

The change is a one-line conditional in a single `except` branch in `CostValidator.compute_node_cost`. The default-arg semantics (`variables: dict | None = None`) are unchanged, so no callers need to update anything. Cost computation degrades gracefully — a query with variables that would multiply the cost by `$value=1000` will now under-count instead of refusing to run, which is the same trade-off the documented callable form makes between releases.

The fix does not touch:
- The `(TypeError, ValueError)` handlers around `compute_cost` (real misconfigurations are still reported).
- `cost_map` validation in `enter_operation_definition` (schema-level errors are still reported).
- The behaviour when the caller passes any non-`None` `variables` dict, including `{}` (test 5 above).

---

*PR drafted with assistance from Claude Code (Anthropic). The change was reviewed manually against ariadne's source. The reproducer block above is the one I used during development; reviewers can paste it verbatim.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cost validator now gracefully handles queries with GraphQL variables when configured without per-request variables, avoiding rejected queries and computing costs by omitting variable-driven multipliers.

* **Tests**
  * Added regression tests for cost validator behavior with required GraphQL variables.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mirumee/ariadne/pull/1325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->