### PR TITLE
docs: fix typos in documentation and pyproject.toml

### DIFF
--- a/docs/01-Docs/03-mutations.md
+++ b/docs/01-Docs/03-mutations.md
@@ -146,7 +146,7 @@ type UsernameMutationResult {
 
 Our client code may first perform an *optimistic update* before the API executes a mutation and returns a response to client. This optimistic update will cause an immediate update of the application interface, making it appear fast and responsive to the user. When the mutation eventually completes a moment later and returns an updated `user` one of two things will happen:
 
-If the mutation succeeded, the user doesn't see another UI update because the new data returned by the mutation was the same as the one set by the optimistic update. If the mutation asked for additional user fields that are dependant on username but weren't set optimistically (like link or user name changes history), those will be updated too.
+If the mutation succeeded, the user doesn't see another UI update because the new data returned by the mutation was the same as the one set by the optimistic update. If the mutation asked for additional user fields that are dependent on username but weren't set optimistically (like link or user name changes history), those will be updated too.
 
 If the mutation failed, changes performed by an optimistic update are overwritten by valid user state that contains the pre-changed username. The client then uses the `error` field to display an error message in the interface.
 

--- a/docs/01-Docs/08-scalars.md
+++ b/docs/01-Docs/08-scalars.md
@@ -87,7 +87,7 @@ If JSON with variables or Query AST is incorrect the server will return `400 BAD
 
 ## Customizing scalar serialization
 
-Consider this API defining the `Story` type with the `publishedOn` field thats date of story publication:
+Consider this API defining the `Story` type with the `publishedOn` field that's date of story publication:
 
 ```graphql
 type Story {

--- a/docs/01-Docs/13-dataloaders.md
+++ b/docs/01-Docs/13-dataloaders.md
@@ -169,7 +169,7 @@ We are now a **half**-way to implementing a dataloader. 👏
 
 ## Dataloader
 
-Dataloader is a proxy to a data source. What this data source is doesn't matter. For performance reasons its important that this source supports bulk retrieval of items, but thats not required.
+Dataloader is a proxy to a data source. What this data source is doesn't matter. For performance reasons its important that this source supports bulk retrieval of items, but that's not required.
 
 Dataloader **knows** how to retrieve required objects in most optimal way.
 

--- a/docs/03-Security/03-disabling-stack-traces.md
+++ b/docs/03-Security/03-disabling-stack-traces.md
@@ -12,7 +12,7 @@ The Ariadne engine includes a debug mode which attaches stacktraces and error pr
 
 In order to protect against engine targeted attacks and ensure that credentials do not leak in stacktraces, it is essential to disable debug mode in production.
 
-The following presents an error occuring when the server tries to fetch data from the database. This response exposes the **complete database URL.**
+The following presents an error occurring when the server tries to fetch data from the database. This response exposes the **complete database URL.**
 
 ```json
 {

--- a/docs/05-Integrations/03-flask-integration.md
+++ b/docs/05-Integrations/03-flask-integration.md
@@ -33,7 +33,7 @@ schema = make_executable_schema(type_defs, query)
 app = Flask(__name__)
 
 # Retrieve HTML for the GraphiQL.
-# If explorer implements logic dependant on current request,
+# If explorer implements logic dependent on current request,
 # change the html(None) call to the html(request)
 # and move this line to the graphql_explorer function.
 explorer_html = ExplorerGraphiQL().html(None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ classifiers = [
 dependencies = [
   "graphql-core>=3.2.0",
   "starlette>0.17,<2.0",
-  "typing_extensions>=4.6.0",  # TODO: Remove this dependency while droping 3.11 support
+  "typing_extensions>=4.6.0",  # TODO: Remove this dependency while dropping 3.11 support
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Fix several typos found across documentation files and `pyproject.toml`:

- `dependant` → `dependent` (docs/05-Integrations/03-flask-integration.md, docs/01-Docs/03-mutations.md)
- `occuring` → `occurring` (docs/03-Security/03-disabling-stack-traces.md)
- `thats` → `that's` (docs/01-Docs/08-scalars.md, docs/01-Docs/13-dataloaders.md)
- `droping` → `dropping` (pyproject.toml comment)

All fixes are in documentation, comments, or prose — no code logic changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected several typos and wording issues across the docs for mutations, scalars, dataloaders, security, and Flask integration.
  * Clarified an example error response description in the security guide.
* **Style**
  * Improved phrasing and spelling in a project configuration comment for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->