### PR TITLE
fix: memoize fragment cost in cost_validator to prevent DoS AR-12

### DIFF
--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -69,8 +69,8 @@ class CostValidator(ValidationRule):
         self.default_complexity = default_complexity
         self.cost = 0
         self.operation_multipliers: list[Any] = []
-        self._fragment_cost_cache: dict[
-            tuple[str, str | None, tuple[Any, ...]], int
+        self._fragment_cost_coefficients: dict[
+            tuple[str, str | None], tuple[int, int]
         ] = {}
 
     def compute_node_cost(  # noqa C901
@@ -150,18 +150,14 @@ class CostValidator(ValidationRule):
                     fragment_type = self.context.schema.get_type(
                         fragment.type_condition.name.value
                     )
-                    cache_key = (
-                        child_node.name.value,
-                        getattr(fragment_type, "name", None),
-                        tuple(self.operation_multipliers),
+                    # Read before get_fragment_cost_coefficients(): it
+                    # recurses into compute_node_cost, which overwrites
+                    # self.operation_multipliers as a side effect.
+                    multiplier_product = reduce(mul, self.operation_multipliers, 1)
+                    coefficient, offset = self.get_fragment_cost_coefficients(
+                        fragment, fragment_type
                     )
-                    if cache_key in self._fragment_cost_cache:
-                        node_cost = self._fragment_cost_cache[cache_key]
-                    else:
-                        node_cost = self.compute_node_cost(
-                            fragment, fragment_type, self.operation_multipliers
-                        )
-                        self._fragment_cost_cache[cache_key] = node_cost
+                    node_cost = coefficient * multiplier_product + offset
             if isinstance(child_node, InlineFragmentNode):
                 inline_fragment_type = type_def
                 if child_node.type_condition and child_node.type_condition.name:
@@ -173,6 +169,32 @@ class CostValidator(ValidationRule):
                 )
             total += node_cost
         return total
+
+    def get_fragment_cost_coefficients(
+        self, fragment: FragmentDefinitionNode, fragment_type
+    ) -> tuple[int, int]:
+        """Return (coefficient, offset) that a fragment's cost under an
+        ancestor multiplier product P is `coefficient * P + offset`.
+
+        A fragment's cost is linear in P, so these are solved from two
+        probe calls to compute_node_cost with different multiplier
+        contexts and cached per (fragment, type) rather than per spread.
+        Without this, a fragment spread under many distinct multiplier
+        contexts (e.g. a compact DAG branching through differently
+        multiplied fields) would be re-walked once per context.
+        """
+        cache_key = (fragment.name.value, getattr(fragment_type, "name", None))
+        if cache_key in self._fragment_cost_coefficients:
+            return self._fragment_cost_coefficients[cache_key]
+
+        cost_at_one = self.compute_node_cost(fragment, fragment_type, [])
+        cost_at_two = self.compute_node_cost(fragment, fragment_type, [2])
+        coefficient = cost_at_two - cost_at_one
+        offset = cost_at_one - coefficient
+
+        coefficients = (coefficient, offset)
+        self._fragment_cost_coefficients[cache_key] = coefficients
+        return coefficients
 
     def enter_operation_definition(self, node, key, parent, path, ancestors):
         if self.cost_map:

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -5,6 +5,7 @@ from typing import Any, cast
 from graphql import (
     GraphQLError,
     GraphQLInterfaceType,
+    GraphQLNamedType,
     GraphQLObjectType,
     GraphQLSchema,
     get_named_type,
@@ -171,7 +172,9 @@ class CostValidator(ValidationRule):
         return total
 
     def get_fragment_cost_coefficients(
-        self, fragment: FragmentDefinitionNode, fragment_type
+        self,
+        fragment: FragmentDefinitionNode,
+        fragment_type: GraphQLNamedType | None,
     ) -> tuple[int, int]:
         """Return (coefficient, offset) that a fragment's cost under an
         ancestor multiplier product P is `coefficient * P + offset`.

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -69,6 +69,9 @@ class CostValidator(ValidationRule):
         self.default_complexity = default_complexity
         self.cost = 0
         self.operation_multipliers: list[Any] = []
+        self._fragment_cost_cache: dict[
+            tuple[str, str | None, tuple[Any, ...]], int
+        ] = {}
 
     def compute_node_cost(  # noqa C901
         self, node: CostAwareNode, type_def, parent_multipliers=None
@@ -147,9 +150,18 @@ class CostValidator(ValidationRule):
                     fragment_type = self.context.schema.get_type(
                         fragment.type_condition.name.value
                     )
-                    node_cost = self.compute_node_cost(
-                        fragment, fragment_type, self.operation_multipliers
+                    cache_key = (
+                        child_node.name.value,
+                        getattr(fragment_type, "name", None),
+                        tuple(self.operation_multipliers),
                     )
+                    if cache_key in self._fragment_cost_cache:
+                        node_cost = self._fragment_cost_cache[cache_key]
+                    else:
+                        node_cost = self.compute_node_cost(
+                            fragment, fragment_type, self.operation_multipliers
+                        )
+                        self._fragment_cost_cache[cache_key] = node_cost
             if isinstance(child_node, InlineFragmentNode):
                 inline_fragment_type = type_def
                 if child_node.type_condition and child_node.type_condition.name:

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -5,6 +5,7 @@ from graphql.validation import validate
 
 from ariadne import make_executable_schema
 from ariadne.validation import cost_validator
+from ariadne.validation.query_cost import CostValidator
 
 cost_directive = """
 directive @cost(
@@ -651,3 +652,57 @@ def test_child_fragment_cost_defined_in_directive_is_multiplied_by_values_from_l
             extensions={"cost": {"requestedQueryCost": 20, "maximumAvailable": 3}},
         )
     ]
+
+
+def test_same_fragment_spread_under_different_multipliers_is_not_cached_across_contexts(
+    schema_with_costs,
+):
+    query = """
+        fragment frag on Child {
+          online
+        }
+        {
+          a: child(value: 3) { ...frag }
+          b: child(value: 7) { ...frag }
+        }
+    """
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=1)
+    result = validate(schema_with_costs, ast, [rule])
+    assert result == [
+        GraphQLError(
+            "The query exceeds the maximum cost of 1. Actual cost is 40",
+            extensions={"cost": {"requestedQueryCost": 40, "maximumAvailable": 1}},
+        )
+    ]
+
+
+def test_fragment_dag_with_repeated_spreads_does_not_cause_exponential_recursion(
+    schema, monkeypatch
+):
+    depth = 30
+    lines = ["query { ...F0 }"]
+    for index in range(depth):
+        if index + 1 < depth:
+            selection = f"...F{index + 1}\n...F{index + 1}"
+        else:
+            selection = "constant"
+        lines.append(f"fragment F{index} on Query {{ {selection} }}")
+    query = "\n".join(lines)
+
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=10**9)
+
+    original_compute_node_cost = CostValidator.compute_node_cost
+    call_count = 0
+
+    def counting_compute_node_cost(self, *args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return original_compute_node_cost(self, *args, **kwargs)
+
+    monkeypatch.setattr(CostValidator, "compute_node_cost", counting_compute_node_cost)
+    result = validate(schema, ast, [rule])
+
+    assert result == []
+    assert call_count <= depth * 2

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -654,7 +654,7 @@ def test_child_fragment_cost_defined_in_directive_is_multiplied_by_values_from_l
     ]
 
 
-def test_same_fragment_spread_under_different_multipliers_is_not_cached_across_contexts(
+def test_same_fragment_spread_under_different_multipliers_is_costed_per_context(
     schema_with_costs,
 ):
     query = """
@@ -677,22 +677,7 @@ def test_same_fragment_spread_under_different_multipliers_is_not_cached_across_c
     ]
 
 
-def test_fragment_dag_with_repeated_spreads_does_not_cause_exponential_recursion(
-    schema, monkeypatch
-):
-    depth = 30
-    lines = ["query { ...F0 }"]
-    for index in range(depth):
-        if index + 1 < depth:
-            selection = f"...F{index + 1}\n...F{index + 1}"
-        else:
-            selection = "constant"
-        lines.append(f"fragment F{index} on Query {{ {selection} }}")
-    query = "\n".join(lines)
-
-    ast = parse(query)
-    rule = cost_validator(maximum_cost=10**9)
-
+def _count_compute_node_cost_calls(monkeypatch):
     original_compute_node_cost = CostValidator.compute_node_cost
     call_count = 0
 
@@ -702,7 +687,47 @@ def test_fragment_dag_with_repeated_spreads_does_not_cause_exponential_recursion
         return original_compute_node_cost(self, *args, **kwargs)
 
     monkeypatch.setattr(CostValidator, "compute_node_cost", counting_compute_node_cost)
+    return lambda: call_count
+
+
+def test_fragment_dag_with_differently_multiplied_branches_does_not_cause_exponential_recursion(  # noqa: E501
+    monkeypatch,
+):
+    cost_directive = """
+        directive @cost(
+            complexity: Int, multipliers: [String!], useMultipliers: Boolean
+        ) on FIELD | FIELD_DEFINITION
+    """
+    type_defs = """
+        type Query {
+          start: Node
+        }
+        type Node {
+          a(value: Int!): Node @cost(complexity: 1, multipliers: ["value"])
+          b(value: Int!): Node @cost(complexity: 1, multipliers: ["value"])
+          leaf: Int!
+        }
+    """
+    schema = make_executable_schema([type_defs, cost_directive])
+
+    depth = 25
+    lines = ["query { start { ...F0 } }"]
+    for index in range(depth):
+        if index + 1 < depth:
+            selection = (
+                f"x: a(value: 2) {{ ...F{index + 1} }} "
+                f"y: b(value: 3) {{ ...F{index + 1} }}"
+            )
+        else:
+            selection = "leaf"
+        lines.append(f"fragment F{index} on Node {{ {selection} }}")
+    query = "\n".join(lines)
+
+    ast = parse(query)
+    rule = cost_validator(maximum_cost=10**100)
+
+    get_call_count = _count_compute_node_cost_calls(monkeypatch)
     result = validate(schema, ast, [rule])
 
     assert result == []
-    assert call_count <= depth * 2
+    assert get_call_count() <= depth * 10


### PR DESCRIPTION
A named fragment spread more than once was re-walked from scratch on every occurrence instead of once. A compact fragment DAG where each fragment spreads the next one twice turned an O(depth) query into O(2^depth) validation work, letting a small request (e.g. depth=24, ~900 bytes) tie up a worker for over 10 seconds before any resolver ran.

Cache each fragment's computed cost by (fragment name, type, current multiplier context) so repeated spreads reuse the prior result instead of recomputing it. The multiplier context is part of the cache key because the same fragment can carry a different cost depending on list-multiplier arguments on the field it's spread under.

Reported by Brian Lee, PhD Security Researcher, SSLab, Georgia Tech

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query cost validation performance when fragment spreads are reused by avoiding repeated fragment re-evaluation across different multiplier contexts.
  * Prevented fragment spread processing from growing excessively, reducing the risk of slowdowns with deeply nested fragment structures.
  * Ensured query cost totals remain correct when the same fragment is used with different argument multiplier contexts.
* **Tests**
  * Added coverage to verify per-context cost accuracy and guard against exponential recursion behavior with fragment “DAG” structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->