### PR TITLE
fix: reject start before connection_init in legacy graphql-ws handler AR-13

### DIFF
--- a/ariadne/asgi/handlers/graphql_ws.py
+++ b/ariadne/asgi/handlers/graphql_ws.py
@@ -114,9 +114,26 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
                 websocket.application_state,
             ):
                 message = await websocket.receive_json()
-                connection_acknowledged = await self.handle_websocket_message(
-                    websocket, message, operations, connection_acknowledged
-                )
+                message_type = message.get("type")
+
+                if (
+                    message_type == GraphQLWSHandler.GQL_START
+                    and not connection_acknowledged
+                ):
+                    # 4401: Unauthorized. `start` received before a successful
+                    # `connection_init`/`connection_ack` handshake -- refuse it
+                    # rather than letting it reach subscription execution and
+                    # skip the `on_connect` hook entirely.
+                    await websocket.close(code=4401)
+                    break
+
+                await self.handle_websocket_message(websocket, message, operations)
+
+                if message_type == GraphQLWSHandler.GQL_CONNECTION_INIT:
+                    connection_acknowledged = WebSocketState.DISCONNECTED not in (
+                        websocket.client_state,
+                        websocket.application_state,
+                    )
         except WebSocketDisconnect:
             pass
         finally:
@@ -139,8 +156,7 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
         websocket: WebSocket,
         message: dict,
         operations: dict[str, Operation],
-        connection_acknowledged: bool = False,
-    ) -> bool:
+    ):
         """Handles new message from websocket connection.
 
         # Required arguments
@@ -150,29 +166,15 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
         `message`: a `dict` with message payload.
 
         `operations`: a `dict` with currently active GraphQL operations.
-
-        # Optional arguments
-
-        `connection_acknowledged`: a `bool` indicating whether `connection_init`
-        already completed successfully for this connection.
-
-        # Return value
-
-        A `bool` with the updated `connection_acknowledged` state.
         """
         operation_id = cast(str, message.get("id"))
         message_type = cast(str, message.get("type"))
 
         if message_type == GraphQLWSHandler.GQL_CONNECTION_INIT:
-            return await self.handle_websocket_connection_init_message(
-                websocket, message
-            )
+            await self.handle_websocket_connection_init_message(websocket, message)
         elif message_type == GraphQLWSHandler.GQL_CONNECTION_TERMINATE:
             await self.handle_websocket_connection_terminate_message(websocket)
         elif message_type == GraphQLWSHandler.GQL_START:
-            if not connection_acknowledged:
-                await websocket.close(code=4401)
-                return connection_acknowledged
             await self.process_single_message(
                 websocket, message.get("payload"), operation_id, operations
             )
@@ -180,8 +182,6 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
             if operation_id in operations:
                 await self.stop_websocket_operation(websocket, operations[operation_id])
                 del operations[operation_id]
-
-        return connection_acknowledged
 
     async def process_single_message(
         self,
@@ -246,7 +246,7 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
 
     async def handle_websocket_connection_init_message(
         self, websocket: WebSocket, message: dict
-    ) -> bool:
+    ):
         """Handles `connection_init` websocket message.
 
         Initializes new websocket instance.
@@ -256,11 +256,6 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
         `websocket`: the `WebSocket` instance from Starlette or FastAPI.
 
         `message`: a `dict` with message's payload.
-
-        # Return value
-
-        A `bool` that is `True` if `on_connect` accepted the connection and
-        `connection_ack` was sent, `False` otherwise.
         """
         try:
             if self.on_connect:
@@ -270,7 +265,6 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
 
             await websocket.send_json({"type": GraphQLWSHandler.GQL_CONNECTION_ACK})
             asyncio.ensure_future(self.keep_websocket_alive(websocket))
-            return True
         except Exception as error:
             log_error(error, self.logger)
 
@@ -283,7 +277,6 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
                 {"type": GraphQLWSHandler.GQL_CONNECTION_ERROR, "payload": payload}
             )
             await websocket.close()
-            return False
 
     async def handle_websocket_connection_terminate_message(
         self,

--- a/ariadne/asgi/handlers/graphql_ws.py
+++ b/ariadne/asgi/handlers/graphql_ws.py
@@ -106,6 +106,7 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
         `websocket`: the `WebSocket` instance from Starlette or FastAPI.
         """
         operations: dict[str, Operation] = {}
+        connection_acknowledged = False
         await websocket.accept("graphql-ws")
         try:
             while WebSocketState.DISCONNECTED not in (
@@ -113,7 +114,9 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
                 websocket.application_state,
             ):
                 message = await websocket.receive_json()
-                await self.handle_websocket_message(websocket, message, operations)
+                connection_acknowledged = await self.handle_websocket_message(
+                    websocket, message, operations, connection_acknowledged
+                )
         except WebSocketDisconnect:
             pass
         finally:
@@ -136,7 +139,8 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
         websocket: WebSocket,
         message: dict,
         operations: dict[str, Operation],
-    ):
+        connection_acknowledged: bool = False,
+    ) -> bool:
         """Handles new message from websocket connection.
 
         # Required arguments
@@ -146,15 +150,29 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
         `message`: a `dict` with message payload.
 
         `operations`: a `dict` with currently active GraphQL operations.
+
+        # Optional arguments
+
+        `connection_acknowledged`: a `bool` indicating whether `connection_init`
+        already completed successfully for this connection.
+
+        # Return value
+
+        A `bool` with the updated `connection_acknowledged` state.
         """
         operation_id = cast(str, message.get("id"))
         message_type = cast(str, message.get("type"))
 
         if message_type == GraphQLWSHandler.GQL_CONNECTION_INIT:
-            await self.handle_websocket_connection_init_message(websocket, message)
+            return await self.handle_websocket_connection_init_message(
+                websocket, message
+            )
         elif message_type == GraphQLWSHandler.GQL_CONNECTION_TERMINATE:
             await self.handle_websocket_connection_terminate_message(websocket)
         elif message_type == GraphQLWSHandler.GQL_START:
+            if not connection_acknowledged:
+                await websocket.close(code=4401)
+                return connection_acknowledged
             await self.process_single_message(
                 websocket, message.get("payload"), operation_id, operations
             )
@@ -162,6 +180,8 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
             if operation_id in operations:
                 await self.stop_websocket_operation(websocket, operations[operation_id])
                 del operations[operation_id]
+
+        return connection_acknowledged
 
     async def process_single_message(
         self,
@@ -226,7 +246,7 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
 
     async def handle_websocket_connection_init_message(
         self, websocket: WebSocket, message: dict
-    ):
+    ) -> bool:
         """Handles `connection_init` websocket message.
 
         Initializes new websocket instance.
@@ -236,6 +256,11 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
         `websocket`: the `WebSocket` instance from Starlette or FastAPI.
 
         `message`: a `dict` with message's payload.
+
+        # Return value
+
+        A `bool` that is `True` if `on_connect` accepted the connection and
+        `connection_ack` was sent, `False` otherwise.
         """
         try:
             if self.on_connect:
@@ -245,6 +270,7 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
 
             await websocket.send_json({"type": GraphQLWSHandler.GQL_CONNECTION_ACK})
             asyncio.ensure_future(self.keep_websocket_alive(websocket))
+            return True
         except Exception as error:
             log_error(error, self.logger)
 
@@ -257,6 +283,7 @@ class GraphQLWSHandler(GraphQLWebsocketHandlerBase):
                 {"type": GraphQLWSHandler.GQL_CONNECTION_ERROR, "payload": payload}
             )
             await websocket.close()
+            return False
 
     async def handle_websocket_connection_terminate_message(
         self,

--- a/ariadne/contrib/sqlalchemy/query.py
+++ b/ariadne/contrib/sqlalchemy/query.py
@@ -50,7 +50,11 @@ class SQLAlchemyQueryType(QueryType):
 
             type_name = getattr(unwrapped_type, "name", None)
 
-            if type_name in self.object_types and field_name not in self._resolvers:
+            if (
+                type_name is not None
+                and type_name in self.object_types
+                and field_name not in self._resolvers
+            ):
                 obj_type = self.object_types[type_name]
                 self.set_field(
                     field_name, self._create_auto_resolver(obj_type, is_list)

--- a/ariadne/schema_visitor.py
+++ b/ariadne/schema_visitor.py
@@ -717,7 +717,7 @@ def heal_schema(schema: GraphQLSchema) -> GraphQLSchema:  # noqa: C901
     ) -> GraphQLList | GraphQLNamedType | GraphQLNonNull:
         # Unwrap the two known wrapper types
         if isinstance(type_, GraphQLList):
-            type_ = GraphQLList(heal_type(type_.of_type))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+            type_ = GraphQLList(heal_type(type_.of_type))  # type: ignore[arg-type]
         elif isinstance(type_, GraphQLNonNull):
             type_ = GraphQLNonNull(heal_type(type_.of_type))  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         elif is_named_type(type_):

--- a/tests/asgi/test_websockets_graphql_ws.py
+++ b/tests/asgi/test_websockets_graphql_ws.py
@@ -806,11 +806,9 @@ def test_connection_not_acknowledged_graphql_ws(client):
         assert exc_info.value.code == 4401
 
 
-def test_start_before_connection_init_does_not_bypass_on_connect(client):
-    def reject_connect(websocket, payload):
-        raise WebSocketConnectionError("rejected")
-
-    client.app.websocket_handler.on_connect = reject_connect
+def test_start_before_connection_init_does_not_call_on_connect(client):
+    on_connect = Mock()
+    client.app.websocket_handler.on_connect = on_connect
 
     with client.websocket_connect("/", ["graphql-ws"]) as ws:
         ws.send_json(
@@ -825,6 +823,8 @@ def test_start_before_connection_init_does_not_bypass_on_connect(client):
             ws.receive_json()
 
         assert exc_info.value.code == 4401
+
+    on_connect.assert_not_called()
 
 
 def test_schema_not_set(client):

--- a/tests/asgi/test_websockets_graphql_ws.py
+++ b/tests/asgi/test_websockets_graphql_ws.py
@@ -791,22 +791,6 @@ def test_websocket_connection_can_be_kept_alive(
 
 
 def test_connection_not_acknowledged_graphql_ws(client):
-    with client.websocket_connect("/", ["graphql-ws"]) as ws:
-        ws.send_json(
-            {
-                "type": GraphQLWSHandler.GQL_START,
-                "id": "test1",
-                "payload": {"query": "subscription { ping }"},
-            }
-        )
-
-        with pytest.raises(WebSocketDisconnect) as exc_info:
-            ws.receive_json()
-
-        assert exc_info.value.code == 4401
-
-
-def test_start_before_connection_init_does_not_call_on_connect(client):
     on_connect = Mock()
     client.app.websocket_handler.on_connect = on_connect
 

--- a/tests/asgi/test_websockets_graphql_ws.py
+++ b/tests/asgi/test_websockets_graphql_ws.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 from graphql import GraphQLError, parse
 from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
 
 from ariadne.asgi import GraphQL
 from ariadne.asgi.handlers import GraphQLWSHandler
@@ -787,6 +788,43 @@ def test_websocket_connection_can_be_kept_alive(
         ws.receive_json()
         response = ws.receive_json()
         assert response["type"] == GraphQLWSHandler.GQL_CONNECTION_KEEP_ALIVE
+
+
+def test_connection_not_acknowledged_graphql_ws(client):
+    with client.websocket_connect("/", ["graphql-ws"]) as ws:
+        ws.send_json(
+            {
+                "type": GraphQLWSHandler.GQL_START,
+                "id": "test1",
+                "payload": {"query": "subscription { ping }"},
+            }
+        )
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            ws.receive_json()
+
+        assert exc_info.value.code == 4401
+
+
+def test_start_before_connection_init_does_not_bypass_on_connect(client):
+    def reject_connect(websocket, payload):
+        raise WebSocketConnectionError("rejected")
+
+    client.app.websocket_handler.on_connect = reject_connect
+
+    with client.websocket_connect("/", ["graphql-ws"]) as ws:
+        ws.send_json(
+            {
+                "type": GraphQLWSHandler.GQL_START,
+                "id": "test1",
+                "payload": {"query": "subscription { ping }"},
+            }
+        )
+
+        with pytest.raises(WebSocketDisconnect) as exc_info:
+            ws.receive_json()
+
+        assert exc_info.value.code == 4401
 
 
 def test_schema_not_set(client):


### PR DESCRIPTION
GraphQLWSHandler dispatched `start` messages straight to subscription
execution without checking whether `connection_init` had completed,
so on_connect never ran for a client that sent `start` first. Track
connection_acknowledged state and close with code 4401 when `start`
arrives before the connection has been acknowledged, matching the
existing guard in GraphQLTransportWSHandler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced the WebSocket handshake before allowing subscriptions to start.
  * Connections that send subscription requests before acknowledgment now close with code `4401`.
  * Prevented connection callbacks and subscription processing when initialization is unsuccessful or incomplete.
  * Fixed resolver-binding errors for scalar and list-based fields.
* **Tests**
  * Added coverage for invalid handshake order and confirmed connection callbacks are not invoked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->