### PR TITLE
fix: count list-valued `@cost` multipliers by their length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,6 @@ For released versions, see the [Releases](https://github.com/mirumee/ariadne/rel
 
 ## Unreleased
 
+### Fixed
 
+- Query cost validation now uses the length of list and tuple arguments named in `multipliers`. Queries that previously passed may exceed `maximum_cost` after upgrading; review affected query costs and thresholds before deployment.

--- a/ariadne/validation/query_cost.py
+++ b/ariadne/validation/query_cost.py
@@ -326,15 +326,15 @@ class CostValidator(ValidationRule):
                 else:
                     val = None
                     break
-            try:
-                if val is not None and not isinstance(val, dict):
+            if isinstance(val, list | tuple):
+                # A list/tuple argument contributes its length, so that e.g.
+                # `field(ids: [ID!]) @cost(multipliers: ["ids"])` costs len(ids).
+                parsed_vals.append(len(val))
+            elif val is not None and not isinstance(val, dict):
+                try:
                     parsed_vals.append(int(val))
-            except (ValueError, TypeError):
-                pass
-        parsed_vals = [
-            len(multiplier) if isinstance(multiplier, list | tuple) else multiplier
-            for multiplier in parsed_vals
-        ]
+                except (ValueError, TypeError):
+                    pass
         return [m for m in parsed_vals if m > 0]
 
     def get_cost_exceeded_error(self) -> GraphQLError:

--- a/docs/06-Extensions/03-query-validators.md
+++ b/docs/06-Extensions/03-query-validators.md
@@ -65,6 +65,18 @@ type Query {
 
 In the above example, final complexity will be multiplied by both `promoted` and `regular` values.
 
+List-valued arguments named in `multipliers` contribute their length:
+
+```graphql
+type Query {
+    posts(ids: [ID!]!): [Post!]! @cost(complexity: 1, multipliers: ["ids"])
+}
+```
+
+Every list argument explicitly named in `multipliers` uses length scaling. To keep an argument from affecting the multiplier, omit its name from `multipliers`; `useMultipliers: false` disables multiplication for the whole field, not for an individual argument. The same behavior applies to Python cost maps, including tuple-valued arguments.
+
+**Upgrade note:** Earlier versions ignored list-valued multipliers. Queries using them can now have higher costs and exceed an existing `maximum_cost` limit. Review representative query costs and thresholds before deploying the update.
+
 You can also use `useMultipliers` to remove query cost multiplication for specified field without removing `@cost` from it:
 
 ```graphql

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -776,3 +776,23 @@ def test_cost_map_multiplier_counts_list_argument_length() -> None:
             extensions={"cost": {"requestedQueryCost": 5, "maximumAvailable": 4}},
         )
     ]
+
+
+def test_cost_directive_multiplier_ignores_non_numeric_argument() -> None:
+    # A multiplier naming a scalar argument that isn't a number contributes
+    # nothing, so the field costs just its complexity.
+    type_defs = """
+        type Query {
+            things(label: String!): Int! @cost(complexity: 3, multipliers: ["label"])
+        }
+    """
+    schema = make_executable_schema([type_defs, cost_directive])
+    ast = parse('{ things(label: "abc") }')
+
+    assert validate(schema, ast, [cost_validator(maximum_cost=3)]) == []
+    assert validate(schema, ast, [cost_validator(maximum_cost=2)]) == [
+        GraphQLError(
+            "The query exceeds the maximum cost of 2. Actual cost is 3",
+            extensions={"cost": {"requestedQueryCost": 3, "maximumAvailable": 2}},
+        )
+    ]

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -731,3 +731,48 @@ def test_fragment_dag_with_differently_multiplied_branches_does_not_cause_expone
 
     assert result == []
     assert get_call_count() <= depth * 10
+
+
+def test_cost_directive_multiplier_counts_list_argument_length():
+    # A list-valued multiplier argument must contribute its length, otherwise a
+    # large list bypasses the maximum-cost guard entirely (the field's cost
+    # collapses to its complexity). Regression test for the dropped list
+    # multiplier in CostValidator.get_multipliers_from_string.
+    type_defs = """
+        type Query {
+            things(ids: [ID!]!): Int! @cost(complexity: 1, multipliers: ["ids"])
+        }
+    """
+    schema = make_executable_schema([type_defs, cost_directive])
+    ast = parse('{ things(ids: ["a", "b", "c", "d", "e"]) }')
+
+    # cost = complexity(1) * len(ids)=5
+    rejected = validate(schema, ast, [cost_validator(maximum_cost=4)])
+    assert rejected == [
+        GraphQLError(
+            "The query exceeds the maximum cost of 4. Actual cost is 5",
+            extensions={"cost": {"requestedQueryCost": 5, "maximumAvailable": 4}},
+        )
+    ]
+    assert validate(schema, ast, [cost_validator(maximum_cost=5)]) == []
+
+
+def test_cost_map_multiplier_counts_list_argument_length():
+    type_defs = """
+        type Query {
+            things(ids: [ID!]!): Int!
+        }
+    """
+    schema = make_executable_schema(type_defs)
+    ast = parse('{ things(ids: ["a", "b", "c", "d", "e"]) }')
+    rule = cost_validator(
+        maximum_cost=4,
+        cost_map={"Query": {"things": {"complexity": 1, "multipliers": ["ids"]}}},
+    )
+    result = validate(schema, ast, [rule])
+    assert result == [
+        GraphQLError(
+            "The query exceeds the maximum cost of 4. Actual cost is 5",
+            extensions={"cost": {"requestedQueryCost": 5, "maximumAvailable": 4}},
+        )
+    ]

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -1,5 +1,8 @@
+from collections.abc import Callable
+from typing import Any
+
 import pytest
-from graphql import GraphQLError
+from graphql import GraphQLError, GraphQLSchema
 from graphql.language import parse
 from graphql.validation import validate
 
@@ -655,8 +658,8 @@ def test_child_fragment_cost_defined_in_directive_is_multiplied_by_values_from_l
 
 
 def test_same_fragment_spread_under_different_multipliers_is_costed_per_context(
-    schema_with_costs,
-):
+    schema_with_costs: GraphQLSchema,
+) -> None:
     query = """
         fragment frag on Child {
           online
@@ -677,11 +680,15 @@ def test_same_fragment_spread_under_different_multipliers_is_costed_per_context(
     ]
 
 
-def _count_compute_node_cost_calls(monkeypatch):
+def _count_compute_node_cost_calls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Callable[[], int]:
     original_compute_node_cost = CostValidator.compute_node_cost
     call_count = 0
 
-    def counting_compute_node_cost(self, *args, **kwargs):
+    def counting_compute_node_cost(
+        self: CostValidator, *args: Any, **kwargs: Any
+    ) -> int:
         nonlocal call_count
         call_count += 1
         return original_compute_node_cost(self, *args, **kwargs)
@@ -690,9 +697,9 @@ def _count_compute_node_cost_calls(monkeypatch):
     return lambda: call_count
 
 
-def test_fragment_dag_with_differently_multiplied_branches_does_not_cause_exponential_recursion(  # noqa: E501
-    monkeypatch,
-):
+def test_fragment_dag_multiplier_contexts_are_linear(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     cost_directive = """
         directive @cost(
             complexity: Int, multipliers: [String!], useMultipliers: Boolean

--- a/tests/test_query_cost_validation.py
+++ b/tests/test_query_cost_validation.py
@@ -733,7 +733,7 @@ def test_fragment_dag_with_differently_multiplied_branches_does_not_cause_expone
     assert get_call_count() <= depth * 10
 
 
-def test_cost_directive_multiplier_counts_list_argument_length():
+def test_cost_directive_multiplier_counts_list_argument_length() -> None:
     # A list-valued multiplier argument must contribute its length, otherwise a
     # large list bypasses the maximum-cost guard entirely (the field's cost
     # collapses to its complexity). Regression test for the dropped list
@@ -757,7 +757,7 @@ def test_cost_directive_multiplier_counts_list_argument_length():
     assert validate(schema, ast, [cost_validator(maximum_cost=5)]) == []
 
 
-def test_cost_map_multiplier_counts_list_argument_length():
+def test_cost_map_multiplier_counts_list_argument_length() -> None:
     type_defs = """
         type Query {
             things(ids: [ID!]!): Int!


### PR DESCRIPTION
## What

The query-cost validator (a DoS-protection control) ignores **list-valued** `@cost` multipliers, so a field's cost collapses to just its `complexity` no matter how large the list argument is — letting a large query slip past `maximum_cost`.

```graphql
# @cost(complexity: 1, multipliers: ["ids"]) — should cost len(ids)
{ things(ids: [ /* 10000 ids */ ]) }   # actually costs 1
```

## Why

In `CostValidator.get_multipliers_from_string` the length step is **dead code**:

```python
try:
    if val is not None and not isinstance(val, dict):
        parsed_vals.append(int(val))        # int([...]) raises TypeError...
except (ValueError, TypeError):
    pass                                    # ...which is swallowed here
parsed_vals = [
    len(multiplier) if isinstance(multiplier, list | tuple) else multiplier  # never sees lists
    for multiplier in parsed_vals
]
```

For a list argument, `int(val)` raises `TypeError`, which the `except` swallows, so the list is dropped **before** the `len()` comprehension runs. `parsed_vals` therefore only ever contains ints, and the intended `len(list)` contribution is lost. This affects both the `@cost` directive path and the `cost_map` path (both call this function).

## How

Handle list/tuple arguments by appending their length *before* the int coercion, and drop the now-redundant post-loop comprehension:

```diff
-            try:
-                if val is not None and not isinstance(val, dict):
-                    parsed_vals.append(int(val))
-            except (ValueError, TypeError):
-                pass
-        parsed_vals = [
-            len(multiplier) if isinstance(multiplier, list | tuple) else multiplier
-            for multiplier in parsed_vals
-        ]
-        return [m for m in parsed_vals if m > 0]
+            if isinstance(val, list | tuple):
+                parsed_vals.append(len(val))
+            elif val is not None and not isinstance(val, dict):
+                try:
+                    parsed_vals.append(int(val))
+                except (ValueError, TypeError):
+                    pass
+        return [m for m in parsed_vals if m > 0]
```

## Tests

Added `test_cost_directive_multiplier_counts_list_argument_length` and `test_cost_map_multiplier_counts_list_argument_length`: a `things(ids: [ID!]) @cost(complexity: 1, multipliers: ["ids"])` field with a 5-element list is rejected at `maximum_cost=4` and allowed at `maximum_cost=5`. Both **fail on `main`** (the query is accepted, cost computed as 1) and pass with this change; the full `test_query_cost_validation.py` suite stays green (34 passed).

---

*Disclosure: this change was prepared with AI assistance and reviewed/verified by me before submission.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Query cost calculations now use the length of list and tuple arguments as multipliers.
  * Non-numeric multiplier arguments no longer add unintended cost; fields are charged only their base complexity.
  * Cost calculations now handle list-valued arguments consistently across directive and configuration-based costing.

* **Documentation**
  * Updated query cost validation guidance with list-multiplier examples and upgrade considerations for existing cost limits.

* **Tests**
  * Added regression coverage for list and tuple multipliers, non-numeric arguments, and consistent query-cost evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->